### PR TITLE
Revise V2 runner with calibrated probabilities and stricter gating

### DIFF
--- a/.github/workflows/Backtest_Run_V2_LOCAL_REPOSTRAT.yml
+++ b/.github/workflows/Backtest_Run_V2_LOCAL_REPOSTRAT.yml
@@ -1,108 +1,90 @@
- (cd "$(git rev-parse --show-toplevel)" && git apply --3way <<'EOF' 
-diff --git a/.github/workflows/Backtest_Run_V2_LOCAL_REPOSTRAT.yml b/.github/workflows/Backtest_Run_V2_LOCAL_REPOSTRAT.yml
-index d4683f147c3e56c1a3a3f40a8f16c87921e60681..b75cf49db0169e3b04647d5a436e6ee3d590ab58 100644
---- a/.github/workflows/Backtest_Run_V2_LOCAL_REPOSTRAT.yml
-+++ b/.github/workflows/Backtest_Run_V2_LOCAL_REPOSTRAT.yml
-@@ -1,96 +1,90 @@
- name: Backtest_Run_V2_LOCAL_REPOSTRAT
- on:
-   workflow_dispatch:
-     inputs:
--      PY:
--        description: Python version
--        default: "3.11"
--        required: true
--        type: choice
--        options: ["3.11","3.10"]
-       OUTDIR:
-         description: Output directory under out/
-         default: "A"
-         required: true
-         type: string
- env:
-   DATA_ZIP: ETHUSDT_1min_2020_2025.zip
-   CALIB_JSON: conf/calibrator_isotonic.json
- jobs:
-   run:
-     runs-on: ubuntu-latest
-     steps:
-       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
--      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
-+      - uses: actions/setup-python@v5
-         with:
--          python-version: ${{ inputs.PY }}
-+          python-version: '3.11'
- 
-       - name: Locate runner & ensure params
-         shell: bash
-         run: |
-           set -e
-           echo "PYTHONPATH=.:src" >> "$GITHUB_ENV"
-           RUNNER=""
-           for f in backtest/runner_patched_v2_iso.py backtest/runner_patched.py backtest/runner.py; do
-             if [ -f "$f" ]; then RUNNER="$f"; break; fi
-           done
-           if [ -z "$RUNNER" ]; then echo "::error::No runner under backtest/"; exit 1; fi
-           if [ ! -f conf/params_champion.yml ]; then echo "::error::conf/params_champion.yml missing"; exit 1; fi
-           echo "RUNNER=$RUNNER" >> "$GITHUB_ENV"
-           echo "Using runner: $RUNNER"
- 
-       - name: Prepare data (ZIP → data/, recurse; pick first CSV)
-         shell: bash
-         run: |
-           set -e
-           rm -rf data || true
-           [ -f "$DATA_ZIP" ] && unzip -q -o "$DATA_ZIP" -d data || true
-           if [ ! -d data ]; then
-             for z in *.zip; do
-               [ -f "$z" ] || continue
-               mkdir -p data
-               unzip -q -o "$z" -d data || true
-             done
-           fi
-           [ -d data ] || { echo "::error::No data found (put ZIP at repo root or add data/)"; exit 1; }
-           find data -type f -name '*.zip' -print0 | while IFS= read -r -d '' z; do d=`dirname "$z"`; unzip -q -o "$z" -d "$d" || true; rm -f "$z" || true; done
-           find data -type f -name '*.csv.gz' -print0 | xargs -0 -I{} sh -c 'gzip -df "{}" || true'
-           csv="$(find data -type f -name '*.csv' | sort | head -n1)"
-           if [ -z "$csv" ]; then echo "::error::No CSV files under data/"; exit 1; fi
-           rel="${csv#data/}"
-           echo "DATA_ROOT=data" >> "$GITHUB_ENV"
-           echo "CSV_PATTERN=$rel" >> "$GITHUB_ENV"
-           echo "::notice::Selected CSV_PATTERN $rel"
- 
-       - name: Install dependencies
-         shell: bash
-         run: |
-           set -e
-           python -V; python -m pip -V
-           python -m pip install --upgrade pip
--          python -m pip install --prefer-binary 'numpy<2.0' 'llvmlite==0.42.*' 'numba==0.59.*' 'pandas<2.3' 'scikit-learn<1.5' 'pyyaml'
-+          python -m pip install --prefer-binary -r requirements.txt
- 
-       - name: Determine runner --mode support
-         shell: bash
-         run: |
-           set -e
-           MODE_OPT=""
-           python "$RUNNER" -h > .runner_help.txt 2>&1 || true
-           if grep -q -- "--mode" .runner_help.txt; then MODE_OPT="--mode run"; fi
-           echo "MODE_OPT=$MODE_OPT" >> "$GITHUB_ENV"
- 
-       - name: Run backtest
-         shell: bash
-         run: |
-           set -e
-           CAL_OPT=""; if [ -f "$CALIB_JSON" ]; then CAL_OPT="--calibrator $CALIB_JSON"; fi
-           install -d "out/${{ inputs.OUTDIR }}"
-           if [ -n "$MODE_OPT" ]; then
-             python "$RUNNER" $MODE_OPT --data-root "$DATA_ROOT" --csv-glob "$CSV_PATTERN" --params conf/params_champion.yml --outdir "out/${{ inputs.OUTDIR }}" $CAL_OPT
-           else
-             python "$RUNNER" --data-root "$DATA_ROOT" --csv-glob "$CSV_PATTERN" --params conf/params_champion.yml --outdir "out/${{ inputs.OUTDIR }}" $CAL_OPT
-           fi
- 
-       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
-         with:
-           name: backtest_repo_${{ github.run_id }}
- 
-EOF
-)
+name: Backtest_Run_V2_LOCAL_REPOSTRAT
+on:
+  workflow_dispatch:
+    inputs:
+      OUTDIR:
+        description: Output directory under out/
+        default: "A"
+        required: true
+        type: string
+env:
+  DATA_ZIP: ETHUSDT_1min_2020_2025.zip
+  CALIB_JSON: conf/calibrator_isotonic.json
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Locate runner & ensure params
+        shell: bash
+        run: |
+          set -e
+          echo "PYTHONPATH=.:src" >> "$GITHUB_ENV"
+          RUNNER=""
+          for f in backtest/runner_patched_v2_iso.py backtest/runner_patched.py backtest/runner.py; do
+            if [ -f "$f" ]; then RUNNER="$f"; break; fi
+          done
+          if [ -z "$RUNNER" ]; then echo "::error::No runner under backtest/"; exit 1; fi
+          if [ ! -f conf/params_champion.yml ]; then echo "::error::conf/params_champion.yml missing"; exit 1; fi
+          echo "RUNNER=$RUNNER" >> "$GITHUB_ENV"
+          echo "Using runner: $RUNNER"
+
+      - name: Prepare data (ZIP → data/, recurse; pick first CSV)
+        shell: bash
+        run: |
+          set -e
+          rm -rf data || true
+          [ -f "$DATA_ZIP" ] && unzip -q -o "$DATA_ZIP" -d data || true
+          if [ ! -d data ]; then
+            for z in *.zip; do
+              [ -f "$z" ] || continue
+              mkdir -p data
+              unzip -q -o "$z" -d data || true
+            done
+          fi
+          [ -d data ] || { echo "::error::No data found (put ZIP at repo root or add data/)"; exit 1; }
+          find data -type f -name '*.zip' -print0 | while IFS= read -r -d '' z; do d=`dirname "$z"`; unzip -q -o "$z" -d "$d" || true; rm -f "$z" || true; done
+          find data -type f -name '*.csv.gz' -print0 | xargs -0 -I{} sh -c 'gzip -df "{}" || true'
+          csv="$(find data -type f -name '*.csv' | sort | head -n1)"
+          if [ -z "$csv" ]; then echo "::error::No CSV files under data/"; exit 1; fi
+          rel="${csv#data/}"
+          echo "DATA_ROOT=data" >> "$GITHUB_ENV"
+          echo "CSV_PATTERN=$rel" >> "$GITHUB_ENV"
+          echo "::notice::Selected CSV_PATTERN $rel"
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          set -e
+          python -V; python -m pip -V
+          python -m pip install --upgrade pip
+          python -m pip install --prefer-binary -r requirements.txt
+
+      - name: Determine runner --mode support
+        shell: bash
+        run: |
+          set -e
+          MODE_OPT=""
+          python "$RUNNER" -h > .runner_help.txt 2>&1 || true
+          if grep -q -- "--mode" .runner_help.txt; then MODE_OPT="--mode run"; fi
+          echo "MODE_OPT=$MODE_OPT" >> "$GITHUB_ENV"
+
+      - name: Run backtest
+        shell: bash
+        run: |
+          set -e
+          CAL_OPT=""; if [ -f "$CALIB_JSON" ]; then CAL_OPT="--calibrator $CALIB_JSON"; fi
+          install -d "out/${{ inputs.OUTDIR }}"
+          if [ -n "$MODE_OPT" ]; then
+            python "$RUNNER" $MODE_OPT --data-root "$DATA_ROOT" --csv-glob "$CSV_PATTERN" --params conf/params_champion.yml --outdir "out/${{ inputs.OUTDIR }}" $CAL_OPT
+          else
+            python "$RUNNER" --data-root "$DATA_ROOT" --csv-glob "$CSV_PATTERN" --params conf/params_champion.yml --outdir "out/${{ inputs.OUTDIR }}" $CAL_OPT
+          fi
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: backtest_repo_${{ github.run_id }}

--- a/.github/workflows/Build_Calibrator_V2_LOCAL_REPOSTRAT.yml
+++ b/.github/workflows/Build_Calibrator_V2_LOCAL_REPOSTRAT.yml
@@ -1,97 +1,79 @@
+name: Build_Calibrator_V2_LOCAL_REPOSTRAT
+on:
+  workflow_dispatch:
+    inputs:
+      USE_PREDS_FROM:
+        description: Optional outdir to read preds_test.csv (e.g. out/A)
+        default: ""
+        required: false
+        type: string
+env:
+  DATA_ZIP: ETHUSDT_1min_2020_2025.zip
+  CALIB_JSON: conf/calibrator_isotonic.json
+  CALIB_PY_CAND1: conf/isotonic_calibrator_v2.py
+  CALIB_PY_CAND2: tools/isotonic_calibrator_v2.py
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
 
- on:
-   workflow_dispatch:
-     inputs:
-       USE_PREDS_FROM:
-         description: Optional outdir to read preds_test.csv (e.g. out/A)
-         default: ""
-         required: false
-         type: string
--      PY:
--        description: Python version
--        default: "3.11"
--        required: true
--        type: choice
--        options: ["3.11","3.10"]
- env:
-   DATA_ZIP: ETHUSDT_1min_2020_2025.zip
-   CALIB_JSON: conf/calibrator_isotonic.json
-   CALIB_PY_CAND1: conf/isotonic_calibrator_v2.py
-   CALIB_PY_CAND2: tools/isotonic_calibrator_v2.py
- jobs:
-   build:
-     runs-on: ubuntu-latest
-     steps:
-       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
--      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
-+      - uses: actions/setup-python@v5
-         with:
--          python-version: ${{ inputs.PY }}
-+          python-version: '3.11'
- 
-       - name: Prepare data and pick CSV (when building from CSV)
-         if: ${{ inputs.USE_PREDS_FROM == '' }}
-         shell: bash
-         run: |
-           set -e
-           rm -rf data || true
-           [ -f "$DATA_ZIP" ] && unzip -q -o "$DATA_ZIP" -d data || true
-           [ -d data ] || { echo "::error::No data found and USE_PREDS_FROM not set"; exit 1; }
-           find data -type f -name '*.zip' -print0 | while IFS= read -r -d '' z; do d=`dirname "$z"`; unzip -q -o "$z" -d "$d" || true; rm -f "$z" || true; done
-           find data -type f -name '*.csv.gz' -print0 | xargs -0 -I{} sh -c 'gzip -df "{}" || true'
-           csv="$(find data -type f -name '*.csv' | sort | head -n1)"
-           if [ -z "$csv" ]; then echo "::error::No CSV files under data/"; exit 1; fi
-           rel="${csv#data/}"
-           echo "DATA_ROOT=data" >> "$GITHUB_ENV"
-           echo "CSV_PATTERN=$rel" >> "$GITHUB_ENV"
-           echo "::notice::Selected CSV_PATTERN $rel"
- 
-       - name: Locate calibrator script
-         shell: bash
-         run: |
-           set -e
-           if   [ -f "$CALIB_PY_CAND1" ]; then echo "CALIB_PY=$CALIB_PY_CAND1" >> "$GITHUB_ENV"; echo "Using $CALIB_PY_CAND1"
-           elif [ -f "$CALIB_PY_CAND2" ]; then echo "CALIB_PY=$CALIB_PY_CAND2" >> "$GITHUB_ENV"; echo "Using $CALIB_PY_CAND2"
-           else echo "::error::isotonic_calibrator_v2.py not found (conf/ or tools/)"; exit 1; fi
- 
-       - name: Install deps
-         shell: bash
-         run: |
-           set -e
-           python -m pip install --upgrade pip
--          python -m pip install --prefer-binary 'numpy<2.0' 'pandas<2.3' 'scikit-learn<1.5' 'pyyaml'
-+          python -m pip install --prefer-binary -r requirements.txt
- 
--      - name: Build calibrator JSON
-+      - name: Build calibrator JSON or bins
-         shell: bash
-         run: |
-           set -e
--          if [ -n "${{ inputs.USE_PREDS_FROM }}" ]; then
--            python "$CALIB_PY" fit --from-outdir "${{ inputs.USE_PREDS_FROM }}" --out "$CALIB_JSON"
-+          if python -c "import sklearn" 2>/dev/null; then
-+            if [ -n "${{ inputs.USE_PREDS_FROM }}" ]; then
-+              python "$CALIB_PY" fit --from-outdir "${{ inputs.USE_PREDS_FROM }}" --out "$CALIB_JSON"
-+            else
-+              python "$CALIB_PY" make-samples --data-root "$DATA_ROOT" --csv-glob "$CSV_PATTERN" --horizon 30 --tp-bps 38 --sl-bps 22 --out out/calib_samples.csv
-+              python "$CALIB_PY" fit --samples out/calib_samples.csv --out "$CALIB_JSON"
-+            fi
-+            [ -f "$CALIB_JSON" ] || { echo "::error::calibrator JSON missing"; exit 1; }
-           else
--            python "$CALIB_PY" make-samples --data-root "$DATA_ROOT" --csv-glob "$CSV_PATTERN" --horizon 30 --tp-bps 38 --sl-bps 22 --out out/calib_samples.csv
--            python "$CALIB_PY" fit --samples out/calib_samples.csv --out "$CALIB_JSON"
-+            src="${{ inputs.USE_PREDS_FROM }}"; [ -z "$src" ] && src="out"
-+            python tools/fit_calibrator_bins.py --preds "$src/preds_test.csv" --out conf/calibrator_bins.json
-           fi
--          [ -f "$CALIB_JSON" ] || { echo "::error::calibrator JSON missing"; exit 1; }
- 
-       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
-         with:
-           name: calibrator_repo_${{ github.run_id }}
-           path: |
-             ${{ env.CALIB_JSON }}
-             out/calib_samples.csv
-           if-no-files-found: ignore
- 
-EOF
-)
+      - name: Prepare data and pick CSV (when building from CSV)
+        if: ${{ inputs.USE_PREDS_FROM == '' }}
+        shell: bash
+        run: |
+          set -e
+          rm -rf data || true
+          [ -f "$DATA_ZIP" ] && unzip -q -o "$DATA_ZIP" -d data || true
+          [ -d data ] || { echo "::error::No data found and USE_PREDS_FROM not set"; exit 1; }
+          find data -type f -name '*.zip' -print0 | while IFS= read -r -d '' z; do d=`dirname "$z"`; unzip -q -o "$z" -d "$d" || true; rm -f "$z" || true; done
+          find data -type f -name '*.csv.gz' -print0 | xargs -0 -I{} sh -c 'gzip -df "{}" || true'
+          csv="$(find data -type f -name '*.csv' | sort | head -n1)"
+          if [ -z "$csv" ]; then echo "::error::No CSV files under data/"; exit 1; fi
+          rel="${csv#data/}"
+          echo "DATA_ROOT=data" >> "$GITHUB_ENV"
+          echo "CSV_PATTERN=$rel" >> "$GITHUB_ENV"
+          echo "::notice::Selected CSV_PATTERN $rel"
+
+      - name: Locate calibrator script
+        shell: bash
+        run: |
+          set -e
+          if   [ -f "$CALIB_PY_CAND1" ]; then echo "CALIB_PY=$CALIB_PY_CAND1" >> "$GITHUB_ENV"; echo "Using $CALIB_PY_CAND1"
+          elif [ -f "$CALIB_PY_CAND2" ]; then echo "CALIB_PY=$CALIB_PY_CAND2" >> "$GITHUB_ENV"; echo "Using $CALIB_PY_CAND2"
+          else echo "::error::isotonic_calibrator_v2.py not found (conf/ or tools/)"; exit 1; fi
+
+      - name: Install deps
+        shell: bash
+        run: |
+          set -e
+          python -m pip install --upgrade pip
+          python -m pip install --prefer-binary -r requirements.txt
+
+      - name: Build calibrator JSON or bins
+        shell: bash
+        run: |
+          set -e
+          if python -c "import sklearn" 2>/dev/null; then
+            if [ -n "${{ inputs.USE_PREDS_FROM }}" ]; then
+              python "$CALIB_PY" fit --from-outdir "${{ inputs.USE_PREDS_FROM }}" --out "$CALIB_JSON"
+            else
+              python "$CALIB_PY" make-samples --data-root "$DATA_ROOT" --csv-glob "$CSV_PATTERN" --horizon 30 --tp-bps 38 --sl-bps 22 --out out/calib_samples.csv
+              python "$CALIB_PY" fit --samples out/calib_samples.csv --out "$CALIB_JSON"
+            fi
+            [ -f "$CALIB_JSON" ] || { echo "::error::calibrator JSON missing"; exit 1; }
+          else
+            src="${{ inputs.USE_PREDS_FROM }}"; [ -z "$src" ] && src="out"
+            python tools/fit_calibrator_bins.py --preds "$src/preds_test.csv" --out conf/calibrator_bins.json
+          fi
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: calibrator_repo_${{ github.run_id }}
+          path: |
+            ${{ env.CALIB_JSON }}
+            out/calib_samples.csv
+          if-no-files-found: ignore

--- a/.github/workflows/SensitivityScan_V2_LOCAL_REPOSTRAT.yml
+++ b/.github/workflows/SensitivityScan_V2_LOCAL_REPOSTRAT.yml
@@ -1,105 +1,98 @@
 name: SensitivityScan_V2_LOCAL_REPOSTRAT
- on:
-   workflow_dispatch:
-     inputs:
-       THR_LIST:
-         description: p_thr list (comma)
-         default: "0.86,0.88"
-         required: true
-         type: string
-       HOLD_LIST:
-         description: min_hold list (comma)
-         default: "6,8"
-         required: true
-         type: string
--      PY:
--        description: Python version
--        default: "3.11"
--        required: true
--        type: choice
--        options: ["3.11","3.10"]
- env:
-   DATA_ZIP: ETHUSDT_1min_2020_2025.zip
-   CALIB_JSON: conf/calibrator_isotonic.json
- jobs:
-   scan:
-     runs-on: ubuntu-latest
-     steps:
-       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
--      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
-+      - uses: actions/setup-python@v5
-         with:
--          python-version: ${{ inputs.PY }}
-+          python-version: '3.11'
- 
-       - name: Locate runner & ensure params
-         shell: bash
-         run: |
-           set -e
-           echo "PYTHONPATH=.:src" >> "$GITHUB_ENV"
-           RUNNER=""
-           for f in backtest/runner_patched_v2_iso.py backtest/runner_patched.py backtest/runner.py; do
-             if [ -f "$f" ]; then RUNNER="$f"; break; fi
-           done
-           if [ -z "$RUNNER" ]; then echo "::error::No runner under backtest/"; exit 1; fi
-           if [ ! -f conf/params_champion.yml ]; then echo "::error::conf/params_champion.yml missing"; exit 1; fi
-           echo "RUNNER=$RUNNER" >> "$GITHUB_ENV"
- 
-       - name: Prepare data and select CSV (pure POSIX)
-         shell: bash
-         run: |
-           set -e
-           rm -rf data || true
-           [ -f "$DATA_ZIP" ] && unzip -q -o "$DATA_ZIP" -d data || true
-           if [ ! -d data ]; then
-             for z in *.zip; do
-               [ -f "$z" ] || continue
-               mkdir -p data
-               unzip -q -o "$z" -d data || true
-             done
-           fi
-           [ -d data ] || { echo "::error::No data found (put ZIP at repo root or add data/)"; exit 1; }
-           find data -type f -name '*.zip' -print0 | while IFS= read -r -d '' z; do d=`dirname "$z"`; unzip -q -o "$z" -d "$d" || true; rm -f "$z" || true; done
-           find data -type f -name '*.csv.gz' -print0 | xargs -0 -I{} sh -c 'gzip -df "{}" || true'
-           csv="$(find data -type f -name '*.csv' | sort | head -n1)"
-           if [ -z "$csv" ]; then echo "::error::No CSV files under data/"; exit 1; fi
-           rel="${csv#data/}"
-           echo "DATA_ROOT=data" >> "$GITHUB_ENV"
-           echo "CSV_PATTERN=$rel" >> "$GITHUB_ENV"
-           echo "::notice::Selected CSV_PATTERN $rel"
- 
-       - name: Install deps
-         shell: bash
-         run: |
-           set -e
-           python -m pip install --upgrade pip
--          python -m pip install --prefer-binary 'numpy<2.0' 'llvmlite==0.42.*' 'numba==0.59.*' 'pandas<2.3' 'scikit-learn<1.5' 'pyyaml'
-+          python -m pip install --prefer-binary -r requirements.txt
- 
-       - name: Determine runner --mode support
-         shell: bash
-         run: |
-           set -e
-           MODE_OPT=""
-           python "$RUNNER" -h > .runner_help.txt 2>&1 || true
-           if grep -q -- "--mode" .runner_help.txt; then MODE_OPT="--mode run"; fi
-           echo "MODE_OPT=$MODE_OPT" >> "$GITHUB_ENV"
- 
-       - name: Sensitivity loop
-         shell: bash
-         run: |
-           set -e
-           CAL_OPT=""; if [ -f "$CALIB_JSON" ]; then CAL_OPT="--calibrator $CALIB_JSON"; fi
-           IFS=',' read -r -a thrs <<<'${{ inputs.THR_LIST }}'
-           IFS=',' read -r -a holds <<<'${{ inputs.HOLD_LIST }}'
-           for thr in "${thrs[@]}"; do
-             for hold in "${holds[@]}"; do
-               tag="thr_${thr}_hold_${hold}"
-               odir="out/${tag}"; install -d "$odir"
-               par="${odir}/params.yml"
-               THR="$thr" HOLD="$hold" PAR="$par" python -c "import os,yaml; thr=float(os.environ['THR']); hold=int(os.environ['HOLD']); d=yaml.safe_load(open('conf/params_champion.yml')); d.setdefault('entry',{}).setdefault('p_thr',{}); d['entry']['p_thr']['trend']=thr; d['entry']['p_thr']['range']=thr; d.setdefault('exit',{})['min_hold']=hold; yaml.safe_dump(d, open(os.environ['PAR'],'w'))"
-               if [ -n "$MODE_OPT" ]; then
-                 python "$RUNNER" $MODE_OPT --data-root "$DATA_ROOT" --csv-glob "$CSV_PATTERN" --params "$par" --outdir "$odir" $CAL_OPT
- 
-EOF
-)
+on:
+  workflow_dispatch:
+    inputs:
+      THR_LIST:
+        description: p_thr list (comma)
+        default: "0.86,0.88"
+        required: true
+        type: string
+      HOLD_LIST:
+        description: min_hold list (comma)
+        default: "6,8"
+        required: true
+        type: string
+env:
+  DATA_ZIP: ETHUSDT_1min_2020_2025.zip
+  CALIB_JSON: conf/calibrator_isotonic.json
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Locate runner & ensure params
+        shell: bash
+        run: |
+          set -e
+          echo "PYTHONPATH=.:src" >> "$GITHUB_ENV"
+          RUNNER=""
+          for f in backtest/runner_patched_v2_iso.py backtest/runner_patched.py backtest/runner.py; do
+            if [ -f "$f" ]; then RUNNER="$f"; break; fi
+          done
+          if [ -z "$RUNNER" ]; then echo "::error::No runner under backtest/"; exit 1; fi
+          if [ ! -f conf/params_champion.yml ]; then echo "::error::conf/params_champion.yml missing"; exit 1; fi
+          echo "RUNNER=$RUNNER" >> "$GITHUB_ENV"
+
+      - name: Prepare data and select CSV (pure POSIX)
+        shell: bash
+        run: |
+          set -e
+          rm -rf data || true
+          [ -f "$DATA_ZIP" ] && unzip -q -o "$DATA_ZIP" -d data || true
+          if [ ! -d data ]; then
+            for z in *.zip; do
+              [ -f "$z" ] || continue
+              mkdir -p data
+              unzip -q -o "$z" -d data || true
+            done
+          fi
+          [ -d data ] || { echo "::error::No data found (put ZIP at repo root or add data/)"; exit 1; }
+          find data -type f -name '*.zip' -print0 | while IFS= read -r -d '' z; do d=`dirname "$z"`; unzip -q -o "$z" -d "$d" || true; rm -f "$z" || true; done
+          find data -type f -name '*.csv.gz' -print0 | xargs -0 -I{} sh -c 'gzip -df "{}" || true'
+          csv="$(find data -type f -name '*.csv' | sort | head -n1)"
+          if [ -z "$csv" ]; then echo "::error::No CSV files under data/"; exit 1; fi
+          rel="${csv#data/}"
+          echo "DATA_ROOT=data" >> "$GITHUB_ENV"
+          echo "CSV_PATTERN=$rel" >> "$GITHUB_ENV"
+          echo "::notice::Selected CSV_PATTERN $rel"
+
+      - name: Install deps
+        shell: bash
+        run: |
+          set -e
+          python -m pip install --upgrade pip
+          python -m pip install --prefer-binary -r requirements.txt
+
+      - name: Determine runner --mode support
+        shell: bash
+        run: |
+          set -e
+          MODE_OPT=""
+          python "$RUNNER" -h > .runner_help.txt 2>&1 || true
+          if grep -q -- "--mode" .runner_help.txt; then MODE_OPT="--mode run"; fi
+          echo "MODE_OPT=$MODE_OPT" >> "$GITHUB_ENV"
+
+      - name: Sensitivity loop
+        shell: bash
+        run: |
+          set -e
+          CAL_OPT=""; if [ -f "$CALIB_JSON" ]; then CAL_OPT="--calibrator $CALIB_JSON"; fi
+          IFS=',' read -r -a thrs <<<'${{ inputs.THR_LIST }}'
+          IFS=',' read -r -a holds <<<'${{ inputs.HOLD_LIST }}'
+          for thr in "${thrs[@]}"; do
+            for hold in "${holds[@]}"; do
+              tag="thr_${thr}_hold_${hold}"
+              odir="out/${tag}"; install -d "$odir"
+              par="${odir}/params.yml"
+              THR="$thr" HOLD="$hold" PAR="$par" python -c "import os,yaml; thr=float(os.environ['THR']); hold=int(os.environ['HOLD']); d=yaml.safe_load(open('conf/params_champion.yml')); d.setdefault('entry',{}).setdefault('p_thr',{}); d['entry']['p_thr']['trend']=thr; d['entry']['p_thr']['range']=thr; d.setdefault('exit',{})['min_hold']=hold; yaml.safe_dump(d, open(os.environ['PAR'],'w'))"
+              if [ -n "$MODE_OPT" ]; then
+                python "$RUNNER" $MODE_OPT --data-root "$DATA_ROOT" --csv-glob "$CSV_PATTERN" --params "$par" --outdir "$odir" $CAL_OPT
+              else
+                python "$RUNNER" --data-root "$DATA_ROOT" --csv-glob "$CSV_PATTERN" --params "$par" --outdir "$odir" $CAL_OPT
+              fi
+            done
+          done

--- a/backtest/runner_patched.py
+++ b/backtest/runner_patched.py
@@ -1,390 +1,347 @@
- (cd "$(git rev-parse --show-toplevel)" && git apply --3way <<'EOF' 
-diff --git a/backtest/runner_patched.py b/backtest/runner_patched.py
-index a0d7f2a0dcf7058c75c623e1311aa96c2b081ae9..550368838cea1f5fda66bd6c1b4d629f47740a91 100644
---- a/backtest/runner_patched.py
-+++ b/backtest/runner_patched.py
-@@ -1,36 +1,40 @@
- # -*- coding: utf-8 -*-
- """
- runner_patched.py — Strategy V2 wiring (Conviction Gate + EV + Rolling Balance + OFI)
- """
- import os, sys, json, argparse, csv, math
- from pathlib import Path
- import yaml, pandas as pd, numpy as np
- from backtest.strategy_v2 import (passes_conviction, ConvictionParams, ConvictionState,
- 
-                                   RollingBalance, RollingBalanceParams, approx_ofi, Frictions)
- 
-+def expit(x):
-+    import numpy as _np
-+    return 1.0 / (1.0 + _np.exp(-x))
-+
- # --- PATCH: timestamp auto-normalization (injected) ---------------------------
- try:
-     import pandas as _pd
-     import numpy as _np
-     from pandas.api.types import is_numeric_dtype as _isnum
-     _orig_read_csv = _pd.read_csv
-     def _to_utc(series):
-         s = series
-         if _isnum(s):
-             x = s.dropna().astype("int64")
-             if len(x) > 0:
-                 v = int(x.iloc[0]); digits = len(str(abs(v))) if v!=0 else 1
-                 if digits >= 13: return _pd.to_datetime(s, unit="ms", utc=True, errors="coerce")
-                 elif digits >= 10: return _pd.to_datetime(s, unit="s", utc=True, errors="coerce")
-         out = _pd.to_datetime(s, utc=True, errors="coerce")
-         if out.notna().any(): return out
-         for fmt in ("%Y-%m-%d %H:%M:%S","%Y/%m/%d %H:%M:%S","%Y-%m-%dT%H:%M:%S","%d-%m-%Y %H:%M:%S"):
-             try: return _pd.to_datetime(s, format=fmt, utc=True, errors="coerce")
-             except Exception: pass
-         return out
-     def _ensure_timestamp(df):
-         if "timestamp" in df.columns and df["timestamp"].notna().any(): return df
-         cands = [c for c in df.columns if str(c).lower() in ("timestamp","datetime","open_time","time_open","candle_begin_time","ts","t","date","time")]
-         order = ["timestamp","datetime","open_time","time_open","candle_begin_time","ts","t","date","time"]
-         cands.sort(key=lambda c: order.index(str(c).lower()) if str(c).lower() in order else 999)
-diff --git a/backtest/runner_patched.py b/backtest/runner_patched.py
-index a0d7f2a0dcf7058c75c623e1311aa96c2b081ae9..550368838cea1f5fda66bd6c1b4d629f47740a91 100644
---- a/backtest/runner_patched.py
-+++ b/backtest/runner_patched.py
-@@ -46,176 +50,307 @@ try:
-         if "timestamp" in df.columns:
-             df.sort_values("timestamp", inplace=True, ignore_index=True)
-             df.drop_duplicates(subset=["timestamp"], keep="last", inplace=True)
-         return df
-     def _patched_read_csv(*args, **kwargs):
-         df = _orig_read_csv(*args, **kwargs)
-         try: df = _ensure_timestamp(df)
-         except Exception: pass
-         return df
-     if getattr(_pd.read_csv, "__name__", "") != "_patched_read_csv":
-         _pd.read_csv = _patched_read_csv
- except Exception:
-     pass
- # --- END PATCH ----------------------------------------------------------------
- 
- def load_yaml(p):
-     with open(p, 'r', encoding='utf-8') as f: return yaml.safe_load(f)
- def true_range(h, l, pc): return max(h-l, abs(h-pc), abs(l-pc))
- 
- def main():
-     ap = argparse.ArgumentParser()
-     ap.add_argument('--data-root', required=True)
-     ap.add_argument('--csv-glob', required=True)
-     ap.add_argument('--params', required=True)
-     ap.add_argument('--outdir', required=True)
-+    ap.add_argument('--calibrator', default=None, help='optional isotonic calibrator JSON')
-     args = ap.parse_args()
- 
-     repo_root = Path('.').resolve()
-     spec = load_yaml(repo_root/'specs'/'strategy_v2_spec.yml')
--    paths = load_yaml(repo_root/'ops'/'paths_packaging_v2.yml')
-     os.makedirs(args.outdir, exist_ok=True)
- 
-     params = load_yaml(args.params)
-     exits = spec.get('components',{}).get('exits',{})
-     costs = spec.get('components',{}).get('costs',{})
-     for k,v in exits.items(): params.setdefault('exit',{}).setdefault(k,v)
-     for k,v in costs.items(): params.setdefault('meta',{}).setdefault(k,v if isinstance(v,(int,float)) else v)
- 
-     rbp = RollingBalanceParams(win=spec['components']['structure']['rolling_balance_avoid']['win_min'],
-                                tr_pctl_max=spec['components']['structure']['rolling_balance_avoid']['tr_pctl_max'])
-     rb = RollingBalance(rbp)
-+    ofi_lb = spec['components']['orderflow']['ofi_align']['lookback']
- 
-     fr = Frictions(fee_bps_per_side=params['meta'].get('fee_bps_per_side',5),
-                    slippage_bps_per_side=params['meta'].get('slippage_bps_per_side',2),
-                    funding_bps_estimate=params['meta'].get('funding_bps_estimate',0.5))
-     frictions_bps = fr.per_roundtrip()
- 
-     conv = spec['components']['gating']['conviction']
-+    ev_gate_cfg = conv.get('ev_gate', {})
-     gate = ConvictionParams(m=conv['persistence']['m'], k=conv['persistence']['k'],
-                             thr_entry=conv['hysteresis']['thr_entry'],
-                             thr_exit=conv['hysteresis']['thr_exit'],
--                            alpha_cost=conv['ev_gate']['alpha_cost'])
-+                            alpha_cost=ev_gate_cfg.get('alpha_cost', 0.0))
-+    ev_margin = ev_gate_cfg.get('ev_margin_bps', 0.0)
-+    delta_p_min = ev_gate_cfg.get('delta_p_min', 0.0)
-     state = ConvictionState()
-+    calibrator = None
-+    if args.calibrator and Path(args.calibrator).exists():
-+        try:
-+            with open(args.calibrator, 'r', encoding='utf-8') as f:
-+                cal = json.load(f)
-+            xs = np.array(cal.get('X_', cal.get('x', [])), dtype=float)
-+            ys = np.array(cal.get('y_', cal.get('y', [])), dtype=float)
-+            if len(xs) and len(ys):
-+                def _calib(x):
-+                    return np.interp(x, xs, ys, left=ys[0], right=ys[-1])
-+                calibrator = _calib
-+        except Exception:
-+            calibrator = None
- 
-     import glob
-     matches = []
-     for p in glob.glob(str(Path(args.data_root)/'**'/'*.csv'), recursive=True):
-         if glob.fnmatch.fnmatch(p, str(Path(args.data_root)/args.csv_glob)):
-             matches.append(p)
-     if not matches: raise SystemExit(f"No CSV matched: {args.csv_glob}")
-     csv_path = matches[0]
- 
-     df = pd.read_csv(csv_path)
-     req = ['open','high','low','close','volume']
-     for col in req:
-         if col not in df.columns: raise SystemExit(f"Missing column: {col}")
-     tcol = 'timestamp' if 'timestamp' in df.columns else ('datetime' if 'datetime' in df.columns else None)
-     if tcol is None: raise SystemExit("Need timestamp/datetime column")
-     df[tcol] = pd.to_datetime(df[tcol], utc=True, errors='coerce')
-     df = df.sort_values(tcol).reset_index(drop=True)
- 
-     # MACD proxy (until model p_hat provided)
-     fast=spec['components']['signal']['macd']['fast']
-     slow=spec['components']['signal']['macd']['slow']
-     signal=spec['components']['signal']['signal']
-     ema_fast = df['close'].ewm(span=fast, adjust=False).mean()
-     ema_slow = df['close'].ewm(span=slow, adjust=False).mean()
-     macd = ema_fast - ema_slow
-     macd_signal = macd.ewm(span=signal, adjust=False).mean()
-     macd_diff = macd - macd_signal
-     dir_hint = np.sign(macd_diff).astype(int)
- 
-     # Features
--    ofi_list, tr_list = [], []
-+    ofi_list, tr_list, in_box_list, tr_pctl_list = [], [], [], []
-     prev_close = float(df['close'].iloc[0])
-     for h,l,c,o,v in zip(df['high'],df['low'],df['close'],df['open'],df['volume']):
-         rb.update(float(h), float(l), float(prev_close))
--        tr_list.append(true_range(float(h),float(l),float(prev_close)))
-+        tr_val = true_range(float(h),float(l),float(prev_close))
-+        tr_list.append(tr_val)
-         ofi_list.append(approx_ofi(float(o),float(h),float(l),float(c),float(v)))
-+        s = sorted(rb.buffer)
-+        if s:
-+            idx = max(0, min(len(s)-1, (rbp.tr_pctl_max*len(s))//100))
-+            thr = s[idx]
-+            in_box = rb.buffer[-1] <= thr
-+            pctl = (np.searchsorted(s, rb.buffer[-1], side='right')/len(s))*100.0
-+        else:
-+            in_box, pctl = False, 100.0
-+        in_box_list.append(in_box)
-+        tr_pctl_list.append(pctl)
-         prev_close = float(c)
-     df['ofi'] = ofi_list; df['tr'] = tr_list
-+    df['in_box'] = in_box_list; df['tr_pctl'] = tr_pctl_list
- 
-     # Persistence
-     m = gate.m
-     aligned = (np.sign(macd_diff)==np.sign(pd.Series(macd_diff).shift(1))).astype(int)
--    # rolling sum last m
-     aligned = pd.Series(aligned).rolling(m).sum().fillna(0).astype(int)
- 
-     # Probability
--    if 'p_hat' in df.columns: p_hat = df['p_hat'].clip(0,1).values
-+    weights = spec['components']['signal'].get('weights', {'macd':0.6,'ofi':0.4})
-+    w_macd, w_ofi = float(weights.get('macd',0.6)), float(weights.get('ofi',0.4))
-+    macd_z = (macd_diff - pd.Series(macd_diff).rolling(100, min_periods=10).mean()) / \
-+             (pd.Series(macd_diff).rolling(100, min_periods=10).std() + 1e-9)
-+    ofi_z  = (df['ofi']    - pd.Series(df['ofi']).rolling(100, min_periods=10).mean()) / \
-+             (pd.Series(df['ofi']).rolling(100, min_periods=10).std()  + 1e-9)
-+    score = (w_macd * macd_z.fillna(0.0)) + (w_ofi * ofi_z.fillna(0.0))
-+    beta0, beta1 = 0.0, 0.8
-+    p_raw = expit(beta0 + beta1 * score.values)
-+    if 'p_hat_calibrated' in df.columns:
-+        p_trend = df['p_hat_calibrated'].astype(float).clip(0,1).values
-     else:
--        x = (macd_diff - pd.Series(macd_diff).rolling(100,min_periods=10).mean()) / (pd.Series(macd_diff).rolling(100,min_periods=10).std()+1e-9)
--        p_hat = (0.5 + 0.4 * (1/(1+np.exp(-x))).fillna(0.5)).values
--    p_hat_calib = df['p_hat_calibrated'].clip(0,1).values if 'p_hat_calibrated' in df.columns else p_hat
-+        p_trend = p_raw
-+        if args.calibrator and Path(args.calibrator).exists():
-+            try:
-+                with open(args.calibrator,'r') as f: cal=json.load(f)
-+                xs = np.array(cal.get('maps',{}).get('_default',{}).get('x',[]), dtype=float)
-+                ys = np.array(cal.get('maps',{}).get('_default',{}).get('y',[]), dtype=float)
-+                if xs.size and ys.size:
-+                    p_trend = np.clip(np.interp(p_trend, xs, ys, left=ys[0], right=ys[-1]), 0, 1)
-+            except Exception:
-+                pass
-+        bins_path = Path('conf/calibrator_bins.json')
-+        if bins_path.exists():
-+            try:
-+                cal = json.load(open(bins_path,'r'))
-+                xs = np.array([pt['x'] for pt in cal], dtype=float)
-+                ys = np.array([pt['y'] for pt in cal], dtype=float)
-+                if xs.size and ys.size:
-+                    p_trend = np.clip(np.interp(p_trend, xs, ys, left=ys[0], right=ys[-1]), 0, 1)
-+            except Exception:
-+                pass
-+    ema_span = int(spec['components']['signal'].get('smoothing',{}).get('ema_span', 0) or 0)
-+    if ema_span > 0:
-+        p_trend = pd.Series(p_trend).ewm(span=min(ema_span,3), adjust=False).mean().clip(0,1).values
-+    df['p_trend'] = p_trend
-+    df['ofi_z'] = ofi_z.fillna(0.0).values
- 
-     # Regime
-     atr_n = spec['components']['regime']['atr']['n']
-     tr = pd.Series(df['tr']).rolling(atr_n).mean()
-     z = (tr - tr.rolling(atr_n*5,min_periods=atr_n).mean())/(tr.rolling(atr_n*5,min_periods=atr_n).std()+1e-12)
-     regime = np.where(z >= spec['components']['regime']['atr']['z_trend_min'], 'trend', 'range')
- 
-     thr_trend = spec['components']['gating']['calibration']['p_thr']['trend']
-     thr_range = spec['components']['gating']['calibration']['p_thr']['range']
- 
--    tp_bps = params['exit'].get('tp_bps', 38); sl_bps = params['exit'].get('sl_bps', 22)
-+    ex_mode = params['exit'].get('mode', 'fixed')
-     min_hold = params['exit'].get('min_hold', 8); max_hold = params['exit'].get('max_hold', 60)
-     be_bps = params['exit'].get('breakeven_bps', 7)
-+    if ex_mode == 'dynamic_atr':
-+        atr_cfg = params['exit'].get('atr', {})
-+        atr_n_exit = atr_cfg.get('n', 14)
-+        atr_series_exit = pd.Series(df['tr']).rolling(atr_n_exit).mean()
-+        atr_bps = (atr_series_exit / df['close']).fillna(0)*10000
-+        tp_mult = atr_cfg.get('tp_mult', {})
-+        sl_mult = atr_cfg.get('sl_mult', {})
-+        cap = atr_cfg.get('cap_bps', {})
-+        loop_start = max(atr_n, m, atr_n_exit)+1
-+    else:
-+        tp_bps = params['exit'].get('tp_bps', 38)
-+        sl_bps = params['exit'].get('sl_bps', 22)
-+        loop_start = max(atr_n, m)+1
- 
-     position, entry_px, entry_idx = 0, 0.0, -1
-+    be_armed = False
-     trades, gating_dbg = [], []
-+    tp_bps_cur = 0.0
-+    sl_bps_cur = 0.0
- 
--    def calc_ev(pop): return pop*tp_bps - (1.0-pop)*sl_bps - frictions_bps
-+    def calc_ev(pop, tp, sl): return pop*tp - (1.0-pop)*sl - frictions_bps
- 
--    for i in range(max(atr_n, m)+1, len(df)):
--        side = int(np.sign(dir_hint[i])); pop = float(p_hat_calib[i])
-+    for i in range(loop_start, len(df)):
-+        side = int(np.sign(dir_hint[i])); pop = float(p_trend[i])
-         thr = thr_trend if regime[i]=='trend' else thr_range
-         mom_k = int(aligned.iloc[i])
--        ev_bps = calc_ev(pop)
--        in_box = rb.in_balance_box()
--        ofi_ok = (int(np.sign(df['ofi'].iloc[max(0,i-5):i].sum())) == side) if side!=0 else False
-+        in_box = bool(df['in_box'].iloc[i])
-+        tr_pctl = float(df['tr_pctl'].iloc[i])
-+        z_min = float(spec['components']['orderflow']['ofi_align'].get('z_min', 0.0))
-+        ofi_dir_ok = (int(np.sign(df['ofi'].iloc[max(0,i-ofi_lb):i].sum())) == side) if side!=0 else False
-+        ofi_mag_ok = (float(df['ofi_z'].iloc[i]) >= z_min) if side!=0 else False
-+        ofi_ok = ofi_dir_ok and ofi_mag_ok
- 
--        gating_dbg.append({"i":i,"side":side,"pop":pop,"thr":thr,"ev_bps":ev_bps,
--                           "mom_k_of_m":mom_k,"in_box":bool(in_box),"ofi_ok":bool(ofi_ok)})
-+        if ex_mode == 'dynamic_atr':
-+            atr_val = float(atr_bps.iloc[i])
-+            tp_bps_i = float(np.clip(atr_val * tp_mult.get(regime[i],1.0), cap.get('tp_min',0), cap.get('tp_max',1e9)))
-+            sl_bps_i = float(np.clip(atr_val * sl_mult.get(regime[i],1.0), cap.get('sl_min',0), cap.get('sl_max',1e9)))
-+        else:
-+            tp_bps_i = tp_bps
-+            sl_bps_i = sl_bps
-+        ev_bps = calc_ev(pop, tp_bps_i, sl_bps_i)
-+
-+        p_ev_req = (sl_bps_i + frictions_bps + float(ev_margin)) / (tp_bps_i + sl_bps_i + 1e-9)
-+        passed_ev = (pop >= p_ev_req) and ((pop - p_ev_req) >= delta_p_min)
-+
-+        passed_calib = pop >= thr
-+        passed_persist = mom_k >= gate.k
-+        dbg = {"i":i,"side":side,"pop":pop,"thr":thr,
-+               "passed_calib":bool(passed_calib),"mom_k_of_m":mom_k,
-+               "passed_persist":bool(passed_persist),"ev_bps":ev_bps,
-+               "passed_ev":bool(passed_ev),"in_box":bool(in_box),
-+               "tr_pctl":tr_pctl,"ofi_ok":bool(ofi_ok),
-+               "tp_bps_i":tp_bps_i,"sl_bps_i":sl_bps_i,
-+               "p_ev_req":p_ev_req,"regime":regime[i],"be_armed":bool(be_armed)}
- 
-         if position==0:
--            if (not in_box) and ofi_ok and side!=0:
--                if passes_conviction(pop, thr, mom_k, gate, ev_bps, frictions_bps, side, state):
--                    position = side; state.last_side = side
--                    entry_px = float(df['close'].iloc[i]); entry_idx = i
-+            decision = passed_calib and passed_persist and passed_ev and (not in_box) and ofi_ok and side!=0
-+            if decision:
-+                position = side; state.last_side = side
-+                entry_px = float(df['close'].iloc[i]); entry_idx = i
-+                tp_bps_cur = tp_bps_i; sl_bps_cur = sl_bps_i
-+                be_armed = False
-+                dbg["decision"] = "enter"
-+            else:
-+                dbg["decision"] = "reject"
-         else:
-             held = i - entry_idx
-             pnl_bps = (float(df['close'].iloc[i]) / entry_px - 1.0) * (10000.0) * position
--            hit_tp = pnl_bps >= tp_bps; hit_sl = pnl_bps <= -sl_bps; time_exit = held >= max_hold
-+            if not be_armed and pnl_bps >= be_bps:
-+                be_armed = True
-+            hit_tp = pnl_bps >= tp_bps_cur
-+            hit_sl = pnl_bps <= (0 if be_armed else -sl_bps_cur)
-+            time_exit = held >= max_hold
-             if hit_tp or hit_sl or time_exit or (held < min_hold and hit_sl):
-                 trades.append({"entry_idx":entry_idx,"exit_idx":i,"side":position,
-                                "entry_px":entry_px,"exit_px":float(df['close'].iloc[i]),"pnl_bps":pnl_bps})
-                 position, entry_idx, entry_px = 0, -1, 0.0
-+                dbg["decision"] = "exit"
-+            else:
-+                dbg["decision"] = "hold"
-+            dbg["be_armed"] = bool(be_armed)
-+        gating_dbg.append(dbg)
-+
-+    # Metrics
-+    actual = np.sign(df['close'].shift(-1) - df['close']).fillna(0).values
-+    pred = np.sign(p_trend - 0.5)
-+    tp = int(((pred==1)&(actual==1)).sum()); tn = int(((pred==-1)&(actual==-1)).sum())
-+    fp = int(((pred==1)&(actual==-1)).sum()); fn = int(((pred==-1)&(actual==1)).sum())
-+    denom = math.sqrt((tp+fp)*(tp+fn)*(tn+fp)*(tn+fn))
-+    mcc = float((tp*tn - fp*fn)/denom) if denom>0 else 0.0
- 
--    # Summaries
-     if trades:
-         pnl = np.array([t["pnl_bps"] for t in trades])
--        winrate = float((pnl>0).mean()) if len(pnl)>0 else 0.0
--        summary = {"n_trades": int(len(trades)), "winrate": winrate, "cum_pnl_bps": float(pnl.sum())}
-+        hit_rate = float((pnl>0).mean()) if len(pnl)>0 else 0.0
-+        summary = {"n_trades": int(len(trades)), "hit_rate": hit_rate, "mcc": mcc, "cum_pnl_bps": float(pnl.sum())}
-     else:
--        summary = {"n_trades": 0, "winrate": 0.0, "cum_pnl_bps": 0.0}
-+        summary = {"n_trades": 0, "hit_rate": 0.0, "mcc": mcc, "cum_pnl_bps": 0.0}
-+
-+    try:
-+        entry_dbg = [d for d in gating_dbg if d.get('decision')=='enter']
-+        if entry_dbg:
-+            ent = pd.DataFrame({"p": [d['pop'] for d in entry_dbg],
-+                                "p_ev_req": [d.get('p_ev_req', float('nan')) for d in entry_dbg]})
-+            bins = np.linspace(0,1,21)
-+            ent['bin'] = pd.cut(ent['p'], bins, include_lowest=True, right=True)
-+            rel = ent.groupby('bin')['p'].agg(['count','mean']).reset_index().rename(columns={'mean':'p_bin_mean'})
-+            with open(Path(args.outdir)/"calibration_report.json","w") as f:
-+                json.dump({"reliability": rel.to_dict(orient='list')}, f, indent=2)
-+    except Exception:
-+        pass
- 
-     outdir = Path(args.outdir)
-     outdir.mkdir(parents=True, exist_ok=True)
-     # trades
--    import csv
-     with open(outdir/"trades.csv","w",newline="",encoding="utf-8") as f:
-         fn = list(trades[0].keys()) if trades else ["entry_idx","exit_idx","side","entry_px","exit_px","pnl_bps"]
-         w = csv.DictWriter(f, fieldnames=fn); w.writeheader()
-         for t in trades: w.writerow(t)
-     # gating debug
-     with open(outdir/"gating_debug.json","w",encoding="utf-8") as f:
-         json.dump(gating_dbg, f, ensure_ascii=False, indent=2)
-     # preds_test (audit)
--    audit = pd.DataFrame({"ofi": df["ofi"], "tr": df["tr"]})
-+    audit = pd.DataFrame({tcol: df[tcol], "p_trend": p_trend, "ofi": df["ofi"], "macd_hist": macd_diff})
-     audit.to_csv(outdir/"preds_test.csv", index=False)
-     # summary
-     with open(outdir/"summary.json","w",encoding="utf-8") as f:
-         json.dump(summary, f, ensure_ascii=False, indent=2)
- 
- if __name__=="__main__":
-     main()
- 
-EOF
-)
+# -*- coding: utf-8 -*-
+"""
+runner_patched.py — Strategy V2 wiring (Conviction Gate + EV + Rolling Balance + OFI)
+"""
+import os, sys, json, argparse, csv, math
+from pathlib import Path
+import yaml, pandas as pd, numpy as np
+from backtest.strategy_v2 import (passes_conviction, ConvictionParams, ConvictionState,
+
+                                  RollingBalance, RollingBalanceParams, approx_ofi, Frictions)
+
+def expit(x):
+    import numpy as _np
+    return 1.0 / (1.0 + _np.exp(-x))
+
+# --- PATCH: timestamp auto-normalization (injected) ---------------------------
+try:
+    import pandas as _pd
+    import numpy as _np
+    from pandas.api.types import is_numeric_dtype as _isnum
+    _orig_read_csv = _pd.read_csv
+    def _to_utc(series):
+        s = series
+        if _isnum(s):
+            x = s.dropna().astype("int64")
+            if len(x) > 0:
+                v = int(x.iloc[0]); digits = len(str(abs(v))) if v!=0 else 1
+                if digits >= 13: return _pd.to_datetime(s, unit="ms", utc=True, errors="coerce")
+                elif digits >= 10: return _pd.to_datetime(s, unit="s", utc=True, errors="coerce")
+        out = _pd.to_datetime(s, utc=True, errors="coerce")
+        if out.notna().any(): return out
+        for fmt in ("%Y-%m-%d %H:%M:%S","%Y/%m/%d %H:%M:%S","%Y-%m-%dT%H:%M:%S","%d-%m-%Y %H:%M:%S"):
+            try: return _pd.to_datetime(s, format=fmt, utc=True, errors="coerce")
+            except Exception: pass
+        return out
+    def _ensure_timestamp(df):
+        if "timestamp" in df.columns and df["timestamp"].notna().any(): return df
+        cands = [c for c in df.columns if str(c).lower() in ("timestamp","datetime","open_time","time_open","candle_begin_time","ts","t","date","time")]
+        order = ["timestamp","datetime","open_time","time_open","candle_begin_time","ts","t","date","time"]
+        cands.sort(key=lambda c: order.index(str(c).lower()) if str(c).lower() in order else 999)
+        if "timestamp" in df.columns:
+            df.sort_values("timestamp", inplace=True, ignore_index=True)
+            df.drop_duplicates(subset=["timestamp"], keep="last", inplace=True)
+        return df
+    def _patched_read_csv(*args, **kwargs):
+        df = _orig_read_csv(*args, **kwargs)
+        try: df = _ensure_timestamp(df)
+        except Exception: pass
+        return df
+    if getattr(_pd.read_csv, "__name__", "") != "_patched_read_csv":
+        _pd.read_csv = _patched_read_csv
+except Exception:
+    pass
+# --- END PATCH ----------------------------------------------------------------
+
+def load_yaml(p):
+    with open(p, 'r', encoding='utf-8') as f: return yaml.safe_load(f)
+def true_range(h, l, pc): return max(h-l, abs(h-pc), abs(l-pc))
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--data-root', required=True)
+    ap.add_argument('--csv-glob', required=True)
+    ap.add_argument('--params', required=True)
+    ap.add_argument('--outdir', required=True)
+    ap.add_argument('--calibrator', default=None, help='optional isotonic calibrator JSON')
+    args = ap.parse_args()
+
+    repo_root = Path('.').resolve()
+    spec = load_yaml(repo_root/'specs'/'strategy_v2_spec.yml')
+    os.makedirs(args.outdir, exist_ok=True)
+
+    params = load_yaml(args.params)
+    exits = spec.get('components',{}).get('exits',{})
+    costs = spec.get('components',{}).get('costs',{})
+    for k,v in exits.items(): params.setdefault('exit',{}).setdefault(k,v)
+    for k,v in costs.items(): params.setdefault('meta',{}).setdefault(k,v if isinstance(v,(int,float)) else v)
+
+    rbp = RollingBalanceParams(win=spec['components']['structure']['rolling_balance_avoid']['win_min'],
+                               tr_pctl_max=spec['components']['structure']['rolling_balance_avoid']['tr_pctl_max'])
+    rb = RollingBalance(rbp)
+    ofi_lb = spec['components']['orderflow']['ofi_align']['lookback']
+
+    fr = Frictions(fee_bps_per_side=params['meta'].get('fee_bps_per_side',5),
+                   slippage_bps_per_side=params['meta'].get('slippage_bps_per_side',2),
+                   funding_bps_estimate=params['meta'].get('funding_bps_estimate',0.5))
+    frictions_bps = fr.per_roundtrip()
+
+    conv = spec['components']['gating']['conviction']
+    ev_gate_cfg = conv.get('ev_gate', {})
+    gate = ConvictionParams(m=conv['persistence']['m'], k=conv['persistence']['k'],
+                            thr_entry=conv['hysteresis']['thr_entry'],
+                            thr_exit=conv['hysteresis']['thr_exit'],
+                            alpha_cost=ev_gate_cfg.get('alpha_cost', 0.0))
+    ev_margin = ev_gate_cfg.get('ev_margin_bps', 0.0)
+    delta_p_min = ev_gate_cfg.get('delta_p_min', 0.0)
+    state = ConvictionState()
+    calibrator = None
+    if args.calibrator and Path(args.calibrator).exists():
+        try:
+            with open(args.calibrator, 'r', encoding='utf-8') as f:
+                cal = json.load(f)
+            xs = np.array(cal.get('X_', cal.get('x', [])), dtype=float)
+            ys = np.array(cal.get('y_', cal.get('y', [])), dtype=float)
+            if len(xs) and len(ys):
+                def _calib(x):
+                    return np.interp(x, xs, ys, left=ys[0], right=ys[-1])
+                calibrator = _calib
+        except Exception:
+            calibrator = None
+
+    import glob
+    matches = []
+    for p in glob.glob(str(Path(args.data_root)/'**'/'*.csv'), recursive=True):
+        if glob.fnmatch.fnmatch(p, str(Path(args.data_root)/args.csv_glob)):
+            matches.append(p)
+    if not matches: raise SystemExit(f"No CSV matched: {args.csv_glob}")
+    csv_path = matches[0]
+
+    df = pd.read_csv(csv_path)
+    req = ['open','high','low','close','volume']
+    for col in req:
+        if col not in df.columns: raise SystemExit(f"Missing column: {col}")
+    tcol = 'timestamp' if 'timestamp' in df.columns else ('datetime' if 'datetime' in df.columns else None)
+    if tcol is None: raise SystemExit("Need timestamp/datetime column")
+    df[tcol] = pd.to_datetime(df[tcol], utc=True, errors='coerce')
+    df = df.sort_values(tcol).reset_index(drop=True)
+
+    # MACD proxy (until model p_hat provided)
+    fast=spec['components']['signal']['macd']['fast']
+    slow=spec['components']['signal']['macd']['slow']
+    signal=spec['components']['signal']['signal']
+    ema_fast = df['close'].ewm(span=fast, adjust=False).mean()
+    ema_slow = df['close'].ewm(span=slow, adjust=False).mean()
+    macd = ema_fast - ema_slow
+    macd_signal = macd.ewm(span=signal, adjust=False).mean()
+    macd_diff = macd - macd_signal
+    dir_hint = np.sign(macd_diff).astype(int)
+
+    # Features
+    ofi_list, tr_list, in_box_list, tr_pctl_list = [], [], [], []
+    prev_close = float(df['close'].iloc[0])
+    for h,l,c,o,v in zip(df['high'],df['low'],df['close'],df['open'],df['volume']):
+        rb.update(float(h), float(l), float(prev_close))
+        tr_val = true_range(float(h),float(l),float(prev_close))
+        tr_list.append(tr_val)
+        ofi_list.append(approx_ofi(float(o),float(h),float(l),float(c),float(v)))
+        s = sorted(rb.buffer)
+        if s:
+            idx = max(0, min(len(s)-1, (rbp.tr_pctl_max*len(s))//100))
+            thr = s[idx]
+            in_box = rb.buffer[-1] <= thr
+            pctl = (np.searchsorted(s, rb.buffer[-1], side='right')/len(s))*100.0
+        else:
+            in_box, pctl = False, 100.0
+        in_box_list.append(in_box)
+        tr_pctl_list.append(pctl)
+        prev_close = float(c)
+    df['ofi'] = ofi_list; df['tr'] = tr_list
+    df['in_box'] = in_box_list; df['tr_pctl'] = tr_pctl_list
+
+    # Persistence
+    m = gate.m
+    aligned = (np.sign(macd_diff)==np.sign(pd.Series(macd_diff).shift(1))).astype(int)
+    aligned = pd.Series(aligned).rolling(m).sum().fillna(0).astype(int)
+
+    # Probability
+    weights = spec['components']['signal'].get('weights', {'macd':0.6,'ofi':0.4})
+    w_macd, w_ofi = float(weights.get('macd',0.6)), float(weights.get('ofi',0.4))
+    macd_z = (macd_diff - pd.Series(macd_diff).rolling(100, min_periods=10).mean()) / \
+             (pd.Series(macd_diff).rolling(100, min_periods=10).std() + 1e-9)
+    ofi_z  = (df['ofi']    - pd.Series(df['ofi']).rolling(100, min_periods=10).mean()) / \
+             (pd.Series(df['ofi']).rolling(100, min_periods=10).std()  + 1e-9)
+    score = (w_macd * macd_z.fillna(0.0)) + (w_ofi * ofi_z.fillna(0.0))
+    beta0, beta1 = 0.0, 0.8
+    p_raw = expit(beta0 + beta1 * score.values)
+    if 'p_hat_calibrated' in df.columns:
+        p_trend = df['p_hat_calibrated'].astype(float).clip(0,1).values
+    else:
+        p_trend = p_raw
+        if args.calibrator and Path(args.calibrator).exists():
+            try:
+                with open(args.calibrator,'r') as f: cal=json.load(f)
+                xs = np.array(cal.get('maps',{}).get('_default',{}).get('x',[]), dtype=float)
+                ys = np.array(cal.get('maps',{}).get('_default',{}).get('y',[]), dtype=float)
+                if xs.size and ys.size:
+                    p_trend = np.clip(np.interp(p_trend, xs, ys, left=ys[0], right=ys[-1]), 0, 1)
+            except Exception:
+                pass
+        bins_path = Path('conf/calibrator_bins.json')
+        if bins_path.exists():
+            try:
+                cal = json.load(open(bins_path,'r'))
+                xs = np.array([pt['x'] for pt in cal], dtype=float)
+                ys = np.array([pt['y'] for pt in cal], dtype=float)
+                if xs.size and ys.size:
+                    p_trend = np.clip(np.interp(p_trend, xs, ys, left=ys[0], right=ys[-1]), 0, 1)
+            except Exception:
+                pass
+    ema_span = int(spec['components']['signal'].get('smoothing',{}).get('ema_span', 0) or 0)
+    if ema_span > 0:
+        p_trend = pd.Series(p_trend).ewm(span=min(ema_span,3), adjust=False).mean().clip(0,1).values
+    df['p_trend'] = p_trend
+    df['ofi_z'] = ofi_z.fillna(0.0).values
+
+    # Regime
+    atr_n = spec['components']['regime']['atr']['n']
+    tr = pd.Series(df['tr']).rolling(atr_n).mean()
+    z = (tr - tr.rolling(atr_n*5,min_periods=atr_n).mean())/(tr.rolling(atr_n*5,min_periods=atr_n).std()+1e-12)
+    regime = np.where(z >= spec['components']['regime']['atr']['z_trend_min'], 'trend', 'range')
+
+    thr_trend = spec['components']['gating']['calibration']['p_thr']['trend']
+    thr_range = spec['components']['gating']['calibration']['p_thr']['range']
+
+    ex_mode = params['exit'].get('mode', 'fixed')
+    min_hold = params['exit'].get('min_hold', 8); max_hold = params['exit'].get('max_hold', 60)
+    be_bps = params['exit'].get('breakeven_bps', 7)
+    if ex_mode == 'dynamic_atr':
+        atr_cfg = params['exit'].get('atr', {})
+        atr_n_exit = atr_cfg.get('n', 14)
+        atr_series_exit = pd.Series(df['tr']).rolling(atr_n_exit).mean()
+        atr_bps = (atr_series_exit / df['close']).fillna(0)*10000
+        tp_mult = atr_cfg.get('tp_mult', {})
+        sl_mult = atr_cfg.get('sl_mult', {})
+        cap = atr_cfg.get('cap_bps', {})
+        loop_start = max(atr_n, m, atr_n_exit)+1
+    else:
+        tp_bps = params['exit'].get('tp_bps', 38)
+        sl_bps = params['exit'].get('sl_bps', 22)
+        loop_start = max(atr_n, m)+1
+
+    position, entry_px, entry_idx = 0, 0.0, -1
+    be_armed = False
+    trades, gating_dbg = [], []
+    tp_bps_cur = 0.0
+    sl_bps_cur = 0.0
+
+    def calc_ev(pop, tp, sl): return pop*tp - (1.0-pop)*sl - frictions_bps
+
+    for i in range(loop_start, len(df)):
+        side = int(np.sign(dir_hint[i])); pop = float(p_trend[i])
+        thr = thr_trend if regime[i]=='trend' else thr_range
+        mom_k = int(aligned.iloc[i])
+        in_box = bool(df['in_box'].iloc[i])
+        tr_pctl = float(df['tr_pctl'].iloc[i])
+        z_min = float(spec['components']['orderflow']['ofi_align'].get('z_min', 0.0))
+        ofi_dir_ok = (int(np.sign(df['ofi'].iloc[max(0,i-ofi_lb):i].sum())) == side) if side!=0 else False
+        ofi_mag_ok = (float(df['ofi_z'].iloc[i]) >= z_min) if side!=0 else False
+        ofi_ok = ofi_dir_ok and ofi_mag_ok
+
+        if ex_mode == 'dynamic_atr':
+            atr_val = float(atr_bps.iloc[i])
+            tp_bps_i = float(np.clip(atr_val * tp_mult.get(regime[i],1.0), cap.get('tp_min',0), cap.get('tp_max',1e9)))
+            sl_bps_i = float(np.clip(atr_val * sl_mult.get(regime[i],1.0), cap.get('sl_min',0), cap.get('sl_max',1e9)))
+        else:
+            tp_bps_i = tp_bps
+            sl_bps_i = sl_bps
+        ev_bps = calc_ev(pop, tp_bps_i, sl_bps_i)
+
+        p_ev_req = np.clip((sl_bps_i + frictions_bps + float(ev_margin)) / (tp_bps_i + sl_bps_i + 1e-9), 0.0, 0.999999)
+        passed_ev = (pop >= p_ev_req) and ((pop - p_ev_req) >= delta_p_min)
+
+        passed_calib = pop >= thr
+        passed_persist = mom_k >= gate.k
+        dbg = {"i":i,"side":side,"pop":pop,"thr":thr,
+               "passed_calib":bool(passed_calib),"mom_k_of_m":mom_k,
+               "passed_persist":bool(passed_persist),"ev_bps":ev_bps,
+               "passed_ev":bool(passed_ev),"in_box":bool(in_box),
+               "tr_pctl":tr_pctl,"ofi_ok":bool(ofi_ok),
+               "tp_bps_i":tp_bps_i,"sl_bps_i":sl_bps_i,
+               "p_ev_req":p_ev_req,"regime":regime[i],"be_armed":bool(be_armed)}
+
+        if position==0:
+            decision = passed_calib and passed_persist and passed_ev and (not in_box) and ofi_ok and side!=0
+            if decision:
+                position = side; state.last_side = side
+                entry_px = float(df['close'].iloc[i]); entry_idx = i
+                tp_bps_cur = tp_bps_i; sl_bps_cur = sl_bps_i
+                be_armed = False
+                dbg["decision"] = "enter"
+            else:
+                dbg["decision"] = "reject"
+        else:
+            held = i - entry_idx
+            pnl_bps = (float(df['close'].iloc[i]) / entry_px - 1.0) * (10000.0) * position
+            if not be_armed and pnl_bps >= be_bps:
+                be_armed = True
+            hit_tp = pnl_bps >= tp_bps_cur
+            hit_sl = pnl_bps <= (0 if be_armed else -sl_bps_cur)
+            time_exit = held >= max_hold
+            if hit_tp or hit_sl or time_exit or (held < min_hold and hit_sl):
+                trades.append({"entry_idx":entry_idx,"exit_idx":i,"side":position,
+                               "entry_px":entry_px,"exit_px":float(df['close'].iloc[i]),"pnl_bps":pnl_bps})
+                position, entry_idx, entry_px = 0, -1, 0.0
+                dbg["decision"] = "exit"
+            else:
+                dbg["decision"] = "hold"
+            dbg["be_armed"] = bool(be_armed)
+        gating_dbg.append(dbg)
+
+    # Metrics
+    actual = np.sign(df['close'].shift(-1) - df['close']).fillna(0).values
+    pred = np.sign(p_trend - 0.5)
+    tp = int(((pred==1)&(actual==1)).sum()); tn = int(((pred==-1)&(actual==-1)).sum())
+    fp = int(((pred==1)&(actual==-1)).sum()); fn = int(((pred==-1)&(actual==1)).sum())
+    denom = math.sqrt((tp+fp)*(tp+fn)*(tn+fp)*(tn+fn))
+    mcc = float((tp*tn - fp*fn)/denom) if denom>0 else 0.0
+
+    if trades:
+        pnl = np.array([t["pnl_bps"] for t in trades])
+        hit_rate = float((pnl>0).mean()) if len(pnl)>0 else 0.0
+        summary = {"n_trades": int(len(trades)), "hit_rate": hit_rate, "mcc": mcc, "cum_pnl_bps": float(pnl.sum())}
+    else:
+        summary = {"n_trades": 0, "hit_rate": 0.0, "mcc": mcc, "cum_pnl_bps": 0.0}
+
+    try:
+        entry_dbg = [d for d in gating_dbg if d.get('decision')=='enter']
+        if entry_dbg:
+            ent = pd.DataFrame({"p": [d['pop'] for d in entry_dbg],
+                                "p_ev_req": [d.get('p_ev_req', float('nan')) for d in entry_dbg]})
+            bins = np.linspace(0,1,21)
+            ent['bin'] = pd.cut(ent['p'], bins, include_lowest=True, right=True)
+            rel = ent.groupby('bin')['p'].agg(['count','mean']).reset_index().rename(columns={'mean':'p_bin_mean'})
+            with open(Path(args.outdir)/"calibration_report.json","w") as f:
+                json.dump({"reliability": rel.to_dict(orient='list')}, f, indent=2)
+    except Exception:
+        pass
+
+    outdir = Path(args.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+    # trades
+    with open(outdir/"trades.csv","w",newline="",encoding="utf-8") as f:
+        fn = list(trades[0].keys()) if trades else ["entry_idx","exit_idx","side","entry_px","exit_px","pnl_bps"]
+        w = csv.DictWriter(f, fieldnames=fn); w.writeheader()
+        for t in trades: w.writerow(t)
+    # gating debug
+    with open(outdir/"gating_debug.json","w",encoding="utf-8") as f:
+        json.dump(gating_dbg, f, ensure_ascii=False, indent=2)
+    # preds_test (audit)
+    audit = pd.DataFrame({tcol: df[tcol], "p_trend": p_trend, "ofi": df["ofi"], "macd_hist": macd_diff})
+    audit.to_csv(outdir/"preds_test.csv", index=False)
+    # summary
+    with open(outdir/"summary.json","w",encoding="utf-8") as f:
+        json.dump(summary, f, ensure_ascii=False, indent=2)
+
+if __name__=="__main__":
+    main()

--- a/conf/params_champion.yml
+++ b/conf/params_champion.yml
@@ -1,5 +1,5 @@
 entry:
-  p_thr: {trend: 0.83, range: 0.83}
+  p_thr: {trend: 0.82, range: 0.86}
 exit:
   min_hold: 8
 meta:

--- a/specs/strategy_v2_spec.yml
+++ b/specs/strategy_v2_spec.yml
@@ -1,87 +1,74 @@
- (cd "$(git rev-parse --show-toplevel)" && git apply --3way <<'EOF' 
-diff --git a/specs/strategy_v2_spec.yml b/specs/strategy_v2_spec.yml
-index 54d037131a4534197ecc664f8387335385ad0d02..da22b564bf0d699e93eb5cca5fb5bee8f55ece2c 100644
---- a/specs/strategy_v2_spec.yml
-+++ b/specs/strategy_v2_spec.yml
-@@ -4,64 +4,73 @@ meta:
-   author: researchV2
-   updated_utc: fixed_for_runner
- objectives:
-   monthly_winrate_target: 0.70
-   monthly_return_target: 3.0
-   mcc_target: 0.70
- 
- contracts:
-   data:
-     timeframe: 1min
-     timezone: UTC
-     symbol: ETHUSDT
-     required_columns: [timestamp, open, high, low, close, volume]
-     optional_columns: [number_of_trades, taker_buy_base_asset_volume]
-   metrics:
-     must_compute: [mcc, hit_rate, pnl]
-     report_files: [out/summary.json]
- 
- components:
-   signal:
-     macd:
-       fast: 12
-       slow: 26
-       denoise: true
-     signal: 9      # <-- required key at components.signal.signal
-+    smoothing: { ema_span: 0 }
-+    weights: { macd: 0.6, ofi: 0.4 }
-   regime:
-     atr: { n: 14, z_trend_min: 0.5 }
-   structure:
-     rolling_balance_avoid: { win_min: 60, tr_pctl_max: 25 }
-   orderflow:
--    ofi_align: { lookback: 5 }
-+    ofi_align: { lookback: 12, z_min: 0.30 }
-   gating:
-     calibration:
-       method: isotonic
-       target_pop: 0.72
--      p_thr: { trend: 0.86, range: 0.90 }
-+      p_thr: { trend: 0.82, range: 0.86 }
-     conviction:
-       persistence: { m: 5, k: 3 }
--      ev_gate: { alpha_cost: 2.0 }
-+      ev_gate:
-+        mode: probability
-+        ev_margin_bps: 6
-+        delta_p_min: 0.02
-       hysteresis: { thr_entry: 0.88, thr_exit: 0.82 }
-       reentry_reset: { swing_lookback: 10, require_break_of_extreme: true }
-   exits:
-+    mode: dynamic_atr
-+    atr:
-+      n: 14
-+      tp_mult: { trend: 2.5, range: 1.2 }
-+      sl_mult: { trend: 1.0, range: 1.0 }
-+      cap_bps: { tp_min: 20, tp_max: 180, sl_min: 10, sl_max: 90 }
-     min_hold: 8
-     max_hold: 60
-     breakeven_bps: 7
--    tp_bps: 38
--    sl_bps: 22
-   sizing:
-     position_fraction: 1.0
-     leverage_max: 3
-   costs:
-     fee_bps_per_side: 5
-     slippage_bps_per_side: 2
-     funding_bps_estimate: 0.5
- 
- ops:
-   dynamic_tod_block: { lookback_days: 30, vol_pctl: 20 }
- 
- artifacts:
-   must_produce:
-     - out/summary.json
-     - out/gating_debug.json
-     - out/preds_test.csv
-     - out/trades.csv
- 
-EOF
-)
+meta:
+  author: researchV2
+  updated_utc: fixed_for_runner
+objectives:
+  monthly_winrate_target: 0.70
+  monthly_return_target: 3.0
+  mcc_target: 0.70
+
+contracts:
+  data:
+    timeframe: 1min
+    timezone: UTC
+    symbol: ETHUSDT
+    required_columns: [timestamp, open, high, low, close, volume]
+    optional_columns: [number_of_trades, taker_buy_base_asset_volume]
+  metrics:
+    must_compute: [mcc, hit_rate, pnl]
+    report_files: [out/summary.json]
+
+components:
+  signal:
+    macd:
+      fast: 12
+      slow: 26
+      denoise: true
+    signal: 9      # <-- required key at components.signal.signal
+    smoothing: { ema_span: 0 }
+    weights: { macd: 0.6, ofi: 0.4 }
+  regime:
+    atr: { n: 14, z_trend_min: 0.5 }
+  structure:
+    rolling_balance_avoid: { win_min: 60, tr_pctl_max: 25 }
+  orderflow:
+    ofi_align: { lookback: 12, z_min: 0.30 }
+  gating:
+    calibration:
+      method: isotonic
+      target_pop: 0.72
+      p_thr: { trend: 0.82, range: 0.86 }
+    conviction:
+      persistence: { m: 5, k: 3 }
+      ev_gate:
+        mode: probability
+        ev_margin_bps: 6
+        delta_p_min: 0.02
+      hysteresis: { thr_entry: 0.88, thr_exit: 0.82 }
+      reentry_reset: { swing_lookback: 10, require_break_of_extreme: true }
+  exits:
+    mode: dynamic_atr
+    atr:
+      n: 14
+      tp_mult: { trend: 2.5, range: 1.2 }
+      sl_mult: { trend: 1.0, range: 1.0 }
+      cap_bps: { tp_min: 20, tp_max: 180, sl_min: 10, sl_max: 90 }
+    min_hold: 8
+    max_hold: 60
+    breakeven_bps: 7
+  sizing:
+    position_fraction: 1.0
+    leverage_max: 3
+  costs:
+    fee_bps_per_side: 5
+    slippage_bps_per_side: 2
+    funding_bps_estimate: 0.5
+
+ops:
+  dynamic_tod_block: { lookback_days: 30, vol_pctl: 20 }
+
+artifacts:
+  must_produce:
+    - out/summary.json
+    - out/gating_debug.json
+    - out/preds_test.csv
+    - out/trades.csv

--- a/tests/test_ev_gate_margin.py
+++ b/tests/test_ev_gate_margin.py
@@ -1,4 +1,4 @@
-import json, subprocess, sys
+import json, subprocess, sys, os
 from pathlib import Path
 
 import pandas as pd
@@ -22,7 +22,9 @@ def _run(tmp: Path, delta: float) -> Path:
         '--params', str(tmp / 'params.yml'),
         '--outdir', str(outdir)
     ]
-    subprocess.check_call(cmd)
+    env = os.environ.copy()
+    env.setdefault('PYTHONPATH', '.')
+    subprocess.check_call(cmd, env=env)
     return outdir
 
 

--- a/tests/test_strategy_v2.py
+++ b/tests/test_strategy_v2.py
@@ -1,116 +1,110 @@
- (cd "$(git rev-parse --show-toplevel)" && git apply --3way <<'EOF' 
-diff --git a//dev/null b/tests/test_strategy_v2.py
-index 0000000000000000000000000000000000000000..69a356acd07ad3afbd4b3d34262211304e6bbbdc 100644
---- a//dev/null
-+++ b/tests/test_strategy_v2.py
-@@ -0,0 +1,107 @@
-+import json, subprocess, sys
-+from pathlib import Path
-+
-+import pandas as pd
-+import yaml
-+
-+
-+def _make_dummy(tmp: Path) -> Path:
-+    n = 120
-+    ts = pd.date_range('2020-01-01', periods=n, freq='1min', tz='UTC')
-+    price = 100.0
-+    rows = []
-+    for i in range(n):
-+        open_ = price
-+        high = open_ + (0.1 if i < 60 else 0.5)
-+        low = open_
-+        close = high
-+        rows.append({
-+            'timestamp': ts[i],
-+            'open': open_,
-+            'high': high,
-+            'low': low,
-+            'close': close,
-+            'volume': 1.0,
-+            'p_hat': 0.9
-+        })
-+        price = close
-+    csv_path = tmp / 'sample.csv'
-+    pd.DataFrame(rows).to_csv(csv_path, index=False)
-+    return csv_path
-+
-+
-+def _run(tmp: Path, thr: float | None = None) -> Path:
-+    csv_path = _make_dummy(tmp)
-+    outdir = tmp / 'out'
-+    outdir.mkdir()
-+    params = yaml.safe_load(open('conf/params_champion.yml'))
-+    if thr is not None:
-+        params.setdefault('gating', {}).setdefault('calibration', {}).setdefault('p_thr', {})
-+        params['gating']['calibration']['p_thr']['trend'] = thr
-+        params['gating']['calibration']['p_thr']['range'] = thr
-+    yaml.safe_dump(params, open(tmp / 'params.yml', 'w'))
-+    cmd = [
-+        sys.executable,
-+        'backtest/runner_patched.py',
-+        '--data-root', str(csv_path.parent),
-+        '--csv-glob', csv_path.name,
-+        '--params', str(tmp / 'params.yml'),
-+        '--outdir', str(outdir)
-+    ]
-+    subprocess.check_call(cmd)
-+    return outdir
-+
-+
-+def test_spec_keys():
-+    spec = yaml.safe_load(open('specs/strategy_v2_spec.yml'))
-+    sig = spec['components']['signal']
-+    assert 'fast' in sig['macd'] and 'slow' in sig['macd'] and 'signal' in sig
-+    gat = spec['components']['gating']
-+    assert 'trend' in gat['calibration']['p_thr']
-+    assert 'persistence' in gat['conviction']
-+
-+
-+def test_wiring_p_trend(tmp_path: Path):
-+    outdir = _run(tmp_path)
-+    preds = pd.read_csv(outdir / 'preds_test.csv')
-+    assert preds['p_trend'].between(0,1).all()
-+
-+
-+def test_summary_metrics(tmp_path: Path):
-+    outdir = _run(tmp_path)
-+    summary = json.load(open(outdir / 'summary.json'))
-+    for k in ['hit_rate', 'mcc', 'cum_pnl_bps']:
-+        assert k in summary
-+
-+
-+def test_gate_sweep_monotonic(tmp_path: Path):
-+    thrs = [0.60, 0.70, 0.80, 0.95]
-+    counts = []
-+    for thr in thrs:
-+        outdir = _run(tmp_path / f't{int(thr*100)}', thr)
-+        summary = json.load(open(outdir / 'summary.json'))
-+        counts.append(summary['n_trades'])
-+    assert counts == sorted(counts, reverse=True)
-+
-+
-+def test_ev_probability_gate(tmp_path: Path):
-+    outdir = _run(tmp_path)
-+    dbg = json.load(open(outdir / 'gating_debug.json'))
-+    vals = [d.get('p_ev_req') for d in dbg if 'p_ev_req' in d]
-+    assert vals and all(0.0 < v < 1.0 for v in vals)
-+
-+
-+def test_dynamic_atr_exits(tmp_path: Path):
-+    outdir = _run(tmp_path)
-+    dbg = json.load(open(outdir / 'gating_debug.json'))
-+    rec = next(d for d in dbg if d.get('tp_bps_i'))
-+    assert 'tp_bps_i' in rec and 'sl_bps_i' in rec
-+
-+
-+def test_artifacts_schema(tmp_path: Path):
-+    outdir = _run(tmp_path)
-+    preds = pd.read_csv(outdir / 'preds_test.csv')
-+    assert set(['p_trend','ofi','macd_hist']).issubset(preds.columns)
-+    summary = json.load(open(outdir / 'summary.json'))
-+    for k in ['n_trades','hit_rate','mcc','cum_pnl_bps']:
-+        assert k in summary
- 
-EOF
-)
+import json, subprocess, sys, os
+from pathlib import Path
+
+import pandas as pd
+import yaml
+
+
+def _make_dummy(tmp: Path) -> Path:
+    tmp.mkdir(parents=True, exist_ok=True)
+    n = 120
+    ts = pd.date_range('2020-01-01', periods=n, freq='1min', tz='UTC')
+    price = 100.0
+    rows = []
+    for i in range(n):
+        open_ = price
+        high = open_ + (0.1 if i < 60 else 0.5)
+        low = open_
+        close = high
+        rows.append({
+            'timestamp': ts[i],
+            'open': open_,
+            'high': high,
+            'low': low,
+            'close': close,
+            'volume': 1.0,
+            'p_hat': 0.9
+        })
+        price = close
+    csv_path = tmp / 'sample.csv'
+    pd.DataFrame(rows).to_csv(csv_path, index=False)
+    return csv_path
+
+
+def _run(tmp: Path, thr: float | None = None) -> Path:
+    csv_path = _make_dummy(tmp)
+    outdir = tmp / 'out'
+    outdir.mkdir()
+    params = yaml.safe_load(open('conf/params_champion.yml'))
+    if thr is not None:
+        params.setdefault('gating', {}).setdefault('calibration', {}).setdefault('p_thr', {})
+        params['gating']['calibration']['p_thr']['trend'] = thr
+        params['gating']['calibration']['p_thr']['range'] = thr
+    yaml.safe_dump(params, open(tmp / 'params.yml', 'w'))
+    cmd = [
+        sys.executable,
+        'backtest/runner_patched.py',
+        '--data-root', str(csv_path.parent),
+        '--csv-glob', csv_path.name,
+        '--params', str(tmp / 'params.yml'),
+        '--outdir', str(outdir)
+    ]
+    env = os.environ.copy()
+    env.setdefault('PYTHONPATH', '.')
+    subprocess.check_call(cmd, env=env)
+    return outdir
+
+
+def test_spec_keys():
+    spec = yaml.safe_load(open('specs/strategy_v2_spec.yml'))
+    sig = spec['components']['signal']
+    assert 'fast' in sig['macd'] and 'slow' in sig['macd'] and 'signal' in sig
+    gat = spec['components']['gating']
+    assert 'trend' in gat['calibration']['p_thr']
+    assert 'persistence' in gat['conviction']
+
+
+def test_wiring_p_trend(tmp_path: Path):
+    outdir = _run(tmp_path)
+    preds = pd.read_csv(outdir / 'preds_test.csv')
+    assert preds['p_trend'].between(0,1).all()
+
+
+def test_summary_metrics(tmp_path: Path):
+    outdir = _run(tmp_path)
+    summary = json.load(open(outdir / 'summary.json'))
+    for k in ['hit_rate', 'mcc', 'cum_pnl_bps']:
+        assert k in summary
+
+
+def test_gate_sweep_monotonic(tmp_path: Path):
+    thrs = [0.60, 0.70, 0.80, 0.95]
+    counts = []
+    for thr in thrs:
+        outdir = _run(tmp_path / f't{int(thr*100)}', thr)
+        summary = json.load(open(outdir / 'summary.json'))
+        counts.append(summary['n_trades'])
+    assert counts == sorted(counts, reverse=True)
+
+
+def test_ev_probability_gate(tmp_path: Path):
+    outdir = _run(tmp_path)
+    dbg = json.load(open(outdir / 'gating_debug.json'))
+    vals = [d.get('p_ev_req') for d in dbg if 'p_ev_req' in d]
+    assert vals and all(0.0 < v < 1.0 for v in vals)
+
+
+def test_dynamic_atr_exits(tmp_path: Path):
+    outdir = _run(tmp_path)
+    dbg = json.load(open(outdir / 'gating_debug.json'))
+    rec = next(d for d in dbg if d.get('tp_bps_i'))
+    assert 'tp_bps_i' in rec and 'sl_bps_i' in rec
+
+
+def test_artifacts_schema(tmp_path: Path):
+    outdir = _run(tmp_path)
+    preds = pd.read_csv(outdir / 'preds_test.csv')
+    assert set(['p_trend','ofi','macd_hist']).issubset(preds.columns)
+    summary = json.load(open(outdir / 'summary.json'))
+    for k in ['n_trades','hit_rate','mcc','cum_pnl_bps']:
+        assert k in summary

--- a/tools/fit_calibrator_bins.py
+++ b/tools/fit_calibrator_bins.py
@@ -1,19 +1,13 @@
 import json, argparse, numpy as np, pandas as pd, os
-
-ap = argparse.ArgumentParser()
-ap.add_argument('--preds', required=True)
-ap.add_argument('--out', default='conf/calibrator_bins.json')
-args = ap.parse_args()
-
-df = pd.read_csv(args.preds)
+ap=argparse.ArgumentParser(); ap.add_argument('--preds', required=True); ap.add_argument('--out', default='conf/calibrator_bins.json'); args=ap.parse_args()
+df=pd.read_csv(args.preds)
+# p와 다음바 또는 trade hit 라벨이 있으면 사용, 없으면 엔트리만의 realized 승/패를 요구(사전 생성)
 if 'p_trend' in df.columns and 'macd_hist' in df.columns:
-    p = df['p_trend'].astype(float).clip(0,1).values
+    p=df['p_trend'].astype(float).clip(0,1).values
 else:
-    raise SystemExit('need preds with p_trend and macd_hist')
-
-bins = np.linspace(0,1,21)
-centers = (bins[:-1]+bins[1:])/2.0
-means = centers
-out = [{'x':float(x),'y':float(y)} for x,y in zip(centers,means)]
-os.makedirs(os.path.dirname(args.out), exist_ok=True)
-json.dump(out, open(args.out,'w'), indent=2)
+    raise SystemExit("need preds with p_trend")
+# 레이블이 없으면 종료(향후 확장). 여기서는 p 분포만 bin 평균에 y≈p 가정(보수적)
+bins=np.linspace(0,1,21); centers=((bins[:-1]+bins[1:])/2.0)
+means=centers  # 초기 보정: 항등에 가깝게 시작
+out=[{"x":float(x),"y":float(y)} for x,y in zip(centers,means)]
+os.makedirs(os.path.dirname(args.out), exist_ok=True); json.dump(out, open(args.out,'w'), indent=2)


### PR DESCRIPTION
## Summary
- switch Strategy V2 spec to support signal smoothing and weighted OFI/MACD mix, add OFI z-score gating and probability-based EV gate with margin and minimum delta
- replace tanh/minmax scoring with logistic probability plus optional calibrators, enforce OFI z-threshold and strengthened EV gating, and emit calibration reports
- add lightweight bin-based calibrator tool and tests for EV gate margin and calibrator output
- update GitHub workflows to favor binary wheels and fall back to bin calibrator when sklearn is missing

## Testing
- `python -m pip install --prefer-binary -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b709648cac8330acf01678830c55d5