### PR TITLE
feat: enhance probability gating and reporting

### DIFF
--- a/backtest/runner_patched.py
+++ b/backtest/runner_patched.py
@@ -314,15 +314,16 @@ def main():
         summary = {"n_trades": 0, "hit_rate": 0.0, "mcc": mcc, "cum_pnl_bps": 0.0}
 
     try:
-        entry_dbg = [d for d in gating_dbg if d.get('decision')=='enter']
-        if entry_dbg:
-            ent = pd.DataFrame({"p": [d['pop'] for d in entry_dbg],
-                                "p_ev_req": [d.get('p_ev_req', float('nan')) for d in entry_dbg]})
-            bins = np.linspace(0,1,21)
-            ent['bin'] = pd.cut(ent['p'], bins, include_lowest=True, right=True)
-            rel = ent.groupby('bin')['p'].agg(['count','mean']).reset_index().rename(columns={'mean':'p_bin_mean'})
-            with open(Path(args.outdir)/"calibration_report.json","w") as f:
-                json.dump({"reliability": rel.to_dict(orient='list')}, f, indent=2)
+        entry_idxs = [t["entry_idx"] for t in trades]
+        ent = pd.DataFrame({
+            "p": [float(p_trend[i]) for i in entry_idxs],
+            "p_ev_req": [float(p_ev_req) if 'p_ev_req' in locals() else np.nan for _ in entry_idxs]
+        })
+        bins = np.linspace(0,1,21)
+        ent['bin'] = pd.cut(ent['p'], bins, include_lowest=True, right=True)
+        rel = ent.groupby('bin')['p'].agg(['count','mean']).reset_index().rename(columns={'mean':'p_bin_mean'})
+        with open(Path(args.outdir)/"calibration_report.json","w") as f:
+            json.dump({"reliability": rel.to_dict(orient="list")}, f, indent=2)
     except Exception:
         pass
 


### PR DESCRIPTION
## Summary
- refine probability model using expit and optional calibrators, persisting OFI z-score
- tighten entry gating with delta_p_min and ofi z thresholds while enriching debug fields
- generate calibration report from trade entries for easier reliability analysis

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b712ed56dc8330ac2f70a703f03c46