### PR TITLE
feat: enhance strategy v2 probability and gating

### DIFF
--- a/tests/test_strategy_v2.py
+++ b/tests/test_strategy_v2.py
@@ -104,7 +104,7 @@ def test_dynamic_atr_exits(tmp_path: Path):
 def test_artifacts_schema(tmp_path: Path):
     outdir = _run(tmp_path)
     preds = pd.read_csv(outdir / 'preds_test.csv')
-    assert set(['p_trend','ofi','macd_hist']).issubset(preds.columns)
+    assert set(['timestamp','p_trend','ofi','macd_hist']).issubset(preds.columns)
     summary = json.load(open(outdir / 'summary.json'))
     for k in ['n_trades','hit_rate','mcc','cum_pnl_bps']:
         assert k in summary


### PR DESCRIPTION
## Summary
- calibrate probability with logistic scoring, optional isotonic/bins smoothing, and OFI z scores
- tighten order-flow and EV gating, writing entry-based calibration reports
- add calibrator bins tool and tests for EV margin and calibrator generation
- normalize timestamp columns from various dataset schemas and assert their presence in preds output

## Testing
- `python -m pip install --prefer-binary -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b712ed56dc8330ac2f70a703f03c46