### PR TITLE
Fix missing path in backtest artifact upload

### DIFF
--- a/.github/workflows/Backtest_Run_V2_LOCAL_REPOSTRAT.yml
+++ b/.github/workflows/Backtest_Run_V2_LOCAL_REPOSTRAT.yml
@@ -88,3 +88,5 @@ jobs:
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: backtest_repo_${{ github.run_id }}
+          path: out/${{ inputs.OUTDIR }}
+          if-no-files-found: warn


### PR DESCRIPTION
## Summary
- specify output directory when uploading backtest artifacts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b718c185cc8330bfaa8ddb7e889753