### PR TITLE
Extend research v2 pipeline with session-aware features

### DIFF
--- a/backtest/__init__.py
+++ b/backtest/__init__.py
@@ -1,0 +1,1 @@
+# Package marker for backtest modules

--- a/backtest/runner_patched.py
+++ b/backtest/runner_patched.py
@@ -152,13 +152,12 @@ def main():
     dir_hint = np.sign(macd_diff).astype(int)
 
     # Features
-    ofi_list, tr_list, in_box_list, tr_pctl_list = [], [], [], []
+    tr_list, in_box_list, tr_pctl_list = [], [], []
     prev_close = float(df['close'].iloc[0])
     for h,l,c,o,v in zip(df['high'],df['low'],df['close'],df['open'],df['volume']):
         rb.update(float(h), float(l), float(prev_close))
         tr_val = true_range(float(h),float(l),float(prev_close))
         tr_list.append(tr_val)
-        ofi_list.append(approx_ofi(float(o),float(h),float(l),float(c),float(v)))
         s = sorted(rb.buffer)
         if s:
             idx = max(0, min(len(s)-1, (rbp.tr_pctl_max*len(s))//100))
@@ -170,8 +169,12 @@ def main():
         in_box_list.append(in_box)
         tr_pctl_list.append(pctl)
         prev_close = float(c)
-    df['ofi'] = ofi_list; df['tr'] = tr_list
-    df['in_box'] = in_box_list; df['tr_pctl'] = tr_pctl_list
+    df['tr'] = tr_list
+    df['in_box'] = in_box_list
+    df['tr_pctl'] = tr_pctl_list
+    ofi_window = params['entry']['ofi']['window']
+    align_ge = params['entry']['ofi']['align_ge']
+    df['ofi'] = approx_ofi(df, window=ofi_window, align_ge=align_ge)
 
     # Persistence
     m = gate.m

--- a/backtest/strategy_v2/__init__.py
+++ b/backtest/strategy_v2/__init__.py
@@ -1,5 +1,14 @@
 from .conviction import passes_conviction, ConvictionParams, ConvictionState
-from .filters import RollingBalance, RollingBalanceParams, approx_ofi
+from .filters import RollingBalance, RollingBalanceParams, approx_ofi, agg_buy_sell_ratio, absorption_proxy
 from .costs import Frictions
-__all__ = ["passes_conviction","ConvictionParams","ConvictionState",
-           "RollingBalance","RollingBalanceParams","approx_ofi","Frictions"]
+__all__ = [
+  "passes_conviction",
+  "ConvictionParams",
+  "ConvictionState",
+  "RollingBalance",
+  "RollingBalanceParams",
+  "approx_ofi",
+  "agg_buy_sell_ratio",
+  "absorption_proxy",
+  "Frictions"
+]

--- a/backtest/strategy_v2/conviction.py
+++ b/backtest/strategy_v2/conviction.py
@@ -6,7 +6,7 @@ class ConvictionParams:
     k:int=3
     thr_entry:float=0.88
     thr_exit:float=0.82
-    alpha_cost:float=2.0
+    alpha_cost:float=1.0  # conservative EV gate 완화(0.8~1.0 범)
 
 class ConvictionState:
     def __init__(self):
@@ -26,3 +26,16 @@ def passes_conviction(p_hat_calib: float,
     if state.last_side != 0 and state.last_side != side:
         if p_hat_calib < params.thr_entry: return False
     return True
+
+def expected_value_bps(p_win: float, tp_bps: float, sl_bps: float, frictions_bps: float) -> float:
+    ev = p_win * tp_bps - (1.0 - p_win) * sl_bps
+    required = ConvictionParams.alpha_cost * frictions_bps
+    return ev - required
+
+def ev_gate_by_regime(regime: str, p_win: float, frictions_bps: float) -> float:
+    # 레짐별 TP/SL 차등 EV 요구치
+    if regime == "trend":
+        tp, sl = 38.0, 22.0
+    else:
+        tp, sl = 30.0, 20.0
+    return expected_value_bps(p_win, tp, sl, frictions_bps)

--- a/backtest/strategy_v2/divergence.py
+++ b/backtest/strategy_v2/divergence.py
@@ -1,0 +1,25 @@
+import numpy as np
+import pandas as pd
+
+def swing_points(df: pd.DataFrame, left: int = 3, right: int = 3):
+  hi = df["high"]
+  lo = df["low"]
+  sh = (hi.shift(left).rolling(left + right + 1).max() == hi).fillna(False)
+  sl = (lo.shift(left).rolling(left + right + 1).min() == lo).fillna(False)
+  return sh, sl
+
+def macd_divergence(df: pd.DataFrame, macd_hist: pd.Series, min_sep: int = 10, min_mag: float = 0.0, ofi_ok=None, vol=None):
+  sh, sl = swing_points(df)
+  bull = (df["low"][sl].diff(min_sep) < 0) & (macd_hist[sl].diff(min_sep) > min_mag)
+  bear = (df["high"][sh].diff(min_sep) > 0) & (macd_hist[sh].diff(min_sep) < -min_mag)
+  sig = pd.Series(False, index=df.index)
+  sig.loc[bull[bull==True].index] = True
+  sig.loc[bear[bear==True].index] = True
+  if ofi_ok is not None:
+    sig &= ofi_ok.astype(bool)
+  if vol is not None:
+    z = (vol - vol.rolling(200).mean()) / (vol.rolling(200).std().replace(0, np.nan))
+    sig &= (z > -1.0)
+  return sig.fillna(False)
+
+__all__ = ["swing_points", "macd_divergence"]

--- a/backtest/strategy_v2/filters.py
+++ b/backtest/strategy_v2/filters.py
@@ -1,28 +1,49 @@
+import numpy as np
 from dataclasses import dataclass
 
 @dataclass
 class RollingBalanceParams:
-    win:int=60  # minutes
-    tr_pctl_max:int=25
+  win: int = 60  # minutes
+  tr_pctl_max: int = 25
 
 class RollingBalance:
-    def __init__(self, params: RollingBalanceParams):
-        self.params=params
-        self.buffer=[]  # store true range values
+  def __init__(self, params: RollingBalanceParams):
+    self.params = params
+    self.buffer = []  # store true range values
 
-    def update(self, high: float, low: float, prev_close: float):
-        tr=max(high-low, abs(high-prev_close), abs(low-prev_close))
-        self.buffer.append(tr)
-        if len(self.buffer)>self.params.win: self.buffer.pop(0)
+  def update(self, high: float, low: float, prev_close: float):
+    tr = max(high - low, abs(high - prev_close), abs(low - prev_close))
+    self.buffer.append(tr)
+    if len(self.buffer) > self.params.win:
+      self.buffer.pop(0)
 
-    def in_balance_box(self) -> bool:
-        if not self.buffer: return False
-        s=sorted(self.buffer)
-        idx=max(0, min(len(s)-1, (self.params.tr_pctl_max*len(s))//100))
-        thr=s[idx]
-        return self.buffer[-1] <= thr
+  def in_balance_box(self) -> bool:
+    if not self.buffer:
+      return False
+    s = sorted(self.buffer)
+    idx = max(0, min(len(s) - 1, (self.params.tr_pctl_max * len(s)) // 100))
+    thr = s[idx]
+    return self.buffer[-1] <= thr
 
-def approx_ofi(o: float, h: float, l: float, c: float, v: float) -> float:
-    rng=(h-l) if h>l else 1e-12
-    loc=(c-l)/rng
-    return (loc-0.5)*2.0 * v
+def approx_ofi(df, window=5, align_ge=3):
+  """
+  경량 OFI: 최근 window 바 중 매수우위/매도우위 부호 정렬이 align_ge 이상일 때 True.
+  """
+  buy = df["taker_buy_volume"] if "taker_buy_volume" in df.columns else df["volume"] * 0
+  sell = (df["volume"] - buy) if "volume" in df.columns else buy * 0
+  sign = np.sign(buy.fillna(0) - sell.fillna(0))
+  roll = sign.rolling(window).sum()
+  return (np.abs(roll) >= align_ge).astype(int)
+
+def agg_buy_sell_ratio(df, window=20):
+  buy = df["taker_buy_volume"] if "taker_buy_volume" in df.columns else df["volume"] * 0
+  num = buy.rolling(window).sum()
+  den = df["volume"].rolling(window).sum().clip(lower=1e-9)
+  return (num / den).clip(0, 1)
+
+def absorption_proxy(df, window=20):
+  # 가격변동 축소 + 체결량 급증 = 흡수(Absorption) 프록시
+  rng = (df["high"] - df["low"]).rolling(window).mean().clip(lower=1e-9)
+  vol = df["volume"].rolling(window).mean()
+  z = (vol - vol.rolling(200).mean()) / (vol.rolling(200).std().replace(0, np.nan))
+  return (z > 1.5) & (rng <= rng.rolling(50).quantile(0.3))

--- a/backtest/strategy_v2/indicators.py
+++ b/backtest/strategy_v2/indicators.py
@@ -1,0 +1,12 @@
+import numpy as np
+import pandas as pd
+
+def atr_1m(df: pd.DataFrame, n: int = 14) -> pd.Series:
+  tr1 = df["high"] - df["low"]
+  tr2 = (df["high"] - df["close"].shift(1)).abs()
+  tr3 = (df["low"] - df["close"].shift(1)).abs()
+  tr = pd.concat([tr1, tr2, tr3], axis=1).max(axis=1)
+  atr = tr.rolling(n).mean()
+  return (atr / df["close"].replace(0, np.nan)).fillna(0)
+
+__all__ = ["atr_1m"]

--- a/backtest/strategy_v2/sizing.py
+++ b/backtest/strategy_v2/sizing.py
@@ -1,0 +1,9 @@
+def conviction_scaled_size(pop: float, cap: float = 1.0, base: float = 0.3) -> float:
+  # 이소토닉 보정확률 기반 선형 스케일
+  return min(cap, max(0.0, base + (pop - 0.5) * 1.4))
+
+def dd_throttle(equity_curve, floor: float = 0.9) -> float:
+  dd = (equity_curve / equity_curve.cummax()).iloc[-1]
+  return 0.5 if dd < floor else 1.0
+
+__all__ = ["conviction_scaled_size", "dd_throttle"]

--- a/backtest/strategy_v2/structure.py
+++ b/backtest/strategy_v2/structure.py
@@ -1,0 +1,61 @@
+import numpy as np
+import pandas as pd
+
+def prior_day_levels(df: pd.DataFrame) -> pd.DataFrame:
+  d = df.copy()
+  d["date"] = pd.to_datetime(d["open_time"]).dt.floor("D")
+  by = d.groupby("date")
+  out = d[["open_time"]].copy()
+  out["PDH"] = by["high"].transform("max").shift(1)
+  out["PDL"] = by["low"].transform("min").shift(1)
+  out["PDc"] = by["close"].transform("last").shift(1)
+  return out[["PDH","PDL","PDc"]]
+
+def prior_week_levels(df: pd.DataFrame) -> pd.DataFrame:
+  d = df.copy()
+  d["week"] = pd.to_datetime(d["open_time"]).dt.to_period("W").dt.start_time
+  by = d.groupby("week")
+  out = d[["open_time"]].copy()
+  out["PWH"] = by["high"].transform("max").shift(1)
+  out["PWL"] = by["low"].transform("min").shift(1)
+  return out[["PWH","PWL"]]
+
+def value_area_approx(df: pd.DataFrame, window: str = "1D", q: float = 0.70, bins: int = 50) -> pd.DataFrame:
+  # 롤링 구간에서 VWAP 분포 기반 VAH/VAL/POC 근사
+  d = df.copy()
+  d["datewin"] = pd.to_datetime(d["open_time"]).dt.floor(window)
+  res = []
+  for key, g in d.groupby("datewin"):
+    px = g["close"].to_numpy()
+    vw = g["volume"].to_numpy().clip(1e-9)
+    hist, edges = np.histogram(px, bins=bins, weights=vw)
+    cdf = np.cumsum(hist) / np.sum(hist)
+    poc_idx = np.argmax(hist)
+    low_idx = np.searchsorted(cdf, (1 - q) / 2.0)
+    high_idx = np.searchsorted(cdf, 1 - (1 - q) / 2.0)
+    VAL = edges[max(low_idx, 0)]
+    VAH = edges[min(high_idx, len(edges) - 1)]
+    POC = edges[poc_idx]
+    res.append(pd.DataFrame({
+      "open_time": g["open_time"],
+      "VAL": VAL,
+      "VAH": VAH,
+      "POC": POC
+    }))
+  return pd.concat(res).set_index("open_time")
+
+def bos_choch(df: pd.DataFrame, swing_len: int = 10):
+  # 간단 BOS/ChoCh: 최근 swing 고저 돌파/전환
+  roll_high = df["high"].rolling(swing_len).max().shift(1)
+  roll_low = df["low"].rolling(swing_len).min().shift(1)
+  bos = (df["close"] > roll_high) | (df["close"] < roll_low)
+  choch = ((df["close"] > roll_high) & (df["close"].shift(1) < roll_high)) | \
+          ((df["close"] < roll_low)  & (df["close"].shift(1) > roll_low))
+  return bos.fillna(False), choch.fillna(False)
+
+__all__ = [
+  "prior_day_levels",
+  "prior_week_levels",
+  "value_area_approx",
+  "bos_choch"
+]

--- a/conf/params_champion.yml
+++ b/conf/params_champion.yml
@@ -1,9 +1,60 @@
-entry:
-  p_thr: {trend: 0.82, range: 0.86}
-exit:
-  min_hold: 8
 meta:
   start_capital: 1000
   position_fraction: 1.0
-  fee_bps_per_side: 5
-  slippage_bps_per_side: 2
+  allow_short: false
+  maker_taker: taker
+  fee_bps_side: 5
+  slip_bps_side: 2
+  funding_bps_rt: 0.5
+
+entry:
+  p_thr:
+    trend: 0.80
+    range: 0.83
+  hysteresis:
+    thr_entry: 0.88
+    thr_exit: 0.82
+  persistence:
+    m: 5
+    k: 3
+  ofi:
+    window: 5
+    align_ge: 3
+  structure:
+    avoid_in_box: true
+
+exit:
+  tp_sl:
+    trend:
+      tp_bps: 38
+      sl_bps: 22
+    range:
+      tp_bps: 30
+      sl_bps: 20
+  min_hold: 8
+  max_hold: 60
+  be:
+    arm_after_bars: 6
+    arm_trigger_bps: 8
+
+regime:
+  detector:
+    atr_len: 14
+    donchian_len: 20
+    atr_norm_on_1m: true
+
+session:
+  asia:
+    p_thr_adj: 0.00
+    exit_tp_adj_bps: 0
+    blacklist_windows: []
+  eu:
+    p_thr_adj: 0.01
+    exit_tp_adj_bps: -3
+    blacklist_windows: []
+  us:
+    p_thr_adj: 0.02
+    exit_tp_adj_bps: -5
+    blacklist_windows:
+      - "13:25-13:35"
+      - "20:55-21:05"

--- a/conf/sensitivity_v2.yml
+++ b/conf/sensitivity_v2.yml
@@ -1,0 +1,12 @@
+grid:
+  p_thr_trend: [0.78, 0.80, 0.82]
+  p_thr_range: [0.82, 0.84, 0.86]
+  alpha_cost: [0.8, 1.0]
+  be_arm_after_bars: [4, 6, 8]
+  min_hold: [6, 8, 10]
+  tp_trend_bps: [34, 38, 44]
+  sl_trend_bps: [18, 22, 26]
+  tp_range_bps: [26, 30, 34]
+  sl_range_bps: [16, 20, 24]
+session_split: [ASIA, EU, US]
+metrics: ["winrate", "mcc", "cum_pnl_bps"]

--- a/contracts/data_contract_v2.json
+++ b/contracts/data_contract_v2.json
@@ -1,38 +1,47 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "OHLCV Minute Data Contract v2",
-  "type": "object",
-  "properties": {
-    "timestamp": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "open": {
-      "type": "number"
-    },
-    "high": {
-      "type": "number"
-    },
-    "low": {
-      "type": "number"
-    },
-    "close": {
-      "type": "number"
-    },
-    "volume": {
-      "type": "number"
-    },
-    "symbol": {
-      "type": "string"
-    }
-  },
-  "required": [
-    "timestamp",
+  "required_columns": [
+    "open_time",
     "open",
     "high",
     "low",
     "close",
     "volume"
   ],
-  "additionalProperties": true
+  "optional_columns": [
+    "vwap",
+    "trades",
+    "funding_rate",
+    "bid",
+    "ask"
+  ],
+  "session_fields": {
+    "tz_base": "UTC",
+    "tz_alt": "Asia/Seoul",
+    "session_tag": [
+      "ASIA",
+      "EU",
+      "US"
+    ]
+  },
+  "cost_fields": {
+    "fee_bps_per_side": {
+      "default": 5,
+      "min": 4,
+      "conservative": true
+    },
+    "slip_bps_per_side": {
+      "default": 2,
+      "min": 2,
+      "conservative": true
+    },
+    "funding_bps_rt": {
+      "default": 0.5,
+      "apply_roll_windows": [
+        "00:00",
+        "08:00",
+        "16:00",
+        "24:00"
+      ]
+    }
+  }
 }

--- a/report/generate_breakdowns.py
+++ b/report/generate_breakdowns.py
@@ -1,0 +1,9 @@
+import pandas as pd
+
+t = pd.read_csv("out/trades.csv")
+g = pd.read_json("out/gating_debug.json", lines=True)
+br = t.groupby(["session","regime"])["pnl_bps"].agg(["count","mean","sum"]).reset_index()
+br.to_csv("out/report_session_regime.csv", index=False)
+cols = ["passed_calib","passed_ev","passed_persist","ofi_ok","in_box"]
+hm = g[cols].astype(int).mean().to_frame("fail_rate").assign(fail_rate=lambda x:1-x["fail_rate"])
+hm.to_csv("out/gate_fail_heatmap.csv")

--- a/tests/test_feature_golden.py
+++ b/tests/test_feature_golden.py
@@ -1,0 +1,25 @@
+import hashlib
+import numpy as np
+import pandas as pd
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from backtest.strategy_v2.filters import approx_ofi
+from backtest.strategy_v2.indicators import atr_1m
+
+def test_feature_golden():
+  df = pd.DataFrame({
+    "open_time": pd.date_range("2020-01-01", periods=5, freq="1min"),
+    "high": np.linspace(100, 101, 5),
+    "low": np.linspace(99, 100, 5),
+    "close": np.linspace(99.5, 100.5, 5),
+    "volume": np.arange(1, 6),
+    "taker_buy_volume": np.arange(5)
+  })
+  atr = atr_1m(df)
+  ofi = approx_ofi(df, window=2, align_ge=1)
+  payload = pd.DataFrame({"atr": atr, "ofi": ofi}).fillna(0).to_csv(index=False)
+  h = hashlib.sha256(payload.encode()).hexdigest()
+  assert h == "f97afd3089c0b9c2aa77edc6ad7e331e72eb73bd7219fc2f88985bdd86225e6f"

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,0 +1,27 @@
+import numpy as np
+import pandas as pd
+import pytest
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from backtest.strategy_v2.filters import approx_ofi, absorption_proxy
+
+@pytest.fixture
+def df_eth_1m():
+  n = 300
+  return pd.DataFrame({
+    "open_time": pd.date_range("2020-01-01", periods=n, freq="1min"),
+    "high": np.linspace(100, 101, n),
+    "low": np.linspace(99, 100, n),
+    "close": np.linspace(99.5, 100.5, n),
+    "volume": np.ones(n),
+    "taker_buy_volume": np.full(n, 0.5)
+  })
+
+def test_ofi_alignment_and_absorption(df_eth_1m):
+  ofi = approx_ofi(df_eth_1m, window=5, align_ge=3)
+  ab = absorption_proxy(df_eth_1m, window=20)
+  assert ofi.isin([0, 1]).all()
+  assert ab.dtype == bool

--- a/tests/test_gate_exit_properties.py
+++ b/tests/test_gate_exit_properties.py
@@ -1,0 +1,64 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+import yaml
+
+
+def _make_dummy(tmp: Path) -> Path:
+  tmp.mkdir(parents=True, exist_ok=True)
+  n = 120
+  ts = pd.date_range('2020-01-01', periods=n, freq='1min', tz='UTC')
+  price = 100.0
+  rows = []
+  for i in range(n):
+    open_ = price
+    high = open_ + (0.1 if i < 60 else 0.5)
+    low = open_
+    close = high
+    rows.append({
+      'timestamp': ts[i],
+      'open': open_,
+      'high': high,
+      'low': low,
+      'close': close,
+      'volume': 1.0,
+      'p_hat': 0.9
+    })
+    price = close
+  csv_path = tmp / 'sample.csv'
+  pd.DataFrame(rows).to_csv(csv_path, index=False)
+  return csv_path
+
+
+def _run(tmp: Path) -> Path:
+  csv_path = _make_dummy(tmp)
+  outdir = tmp / 'out'
+  outdir.mkdir()
+  params = yaml.safe_load(open('conf/params_champion.yml'))
+  yaml.safe_dump(params, open(tmp / 'params.yml', 'w'))
+  cmd = [
+    sys.executable,
+    'backtest/runner_patched.py',
+    '--data-root', str(csv_path.parent),
+    '--csv-glob', csv_path.name,
+    '--params', str(tmp / 'params.yml'),
+    '--outdir', str(outdir)
+  ]
+  env = {'PYTHONPATH': '.'}
+  subprocess.check_call(cmd, env=env)
+  return outdir
+
+
+@pytest.fixture
+def sim_trades(tmp_path: Path):
+  outdir = _run(tmp_path)
+  return pd.read_csv(outdir / 'trades.csv')
+
+
+def test_min_hold_never_violated(sim_trades):
+  if 'bars_held' in sim_trades.columns:
+    assert (sim_trades['bars_held'] >= 8).all()

--- a/tools/calibrate_isotonic.py
+++ b/tools/calibrate_isotonic.py
@@ -7,11 +7,18 @@ import pandas as pd
 from sklearn.isotonic import IsotonicRegression
 
 
+def fit_isotonic(x, y):
+    ir = IsotonicRegression(out_of_bounds='clip')
+    ir.fit(x, y)
+    return {'x': ir.X_.tolist(), 'y': ir.y_.tolist()}
+
 def main():
     ap = argparse.ArgumentParser(description="Fit isotonic calibrator")
     ap.add_argument('--preds', required=True, help='CSV with p_raw and optional y or close columns')
     ap.add_argument('--horizon', type=int, default=5, help='label horizon in bars')
     ap.add_argument('--out', default='conf/calibrator_isotonic.json', help='output JSON path')
+    ap.add_argument('--group-keys', default=None, help='comma separated column names')
+    ap.add_argument('--min-bin', type=int, default=100)
     args = ap.parse_args()
 
     df = pd.read_csv(args.preds)
@@ -22,15 +29,22 @@ def main():
             df['y'] = (df['close'].shift(-args.horizon) > df['close']).astype(float)
         else:
             raise SystemExit('need y or close column')
-    ir = IsotonicRegression(out_of_bounds='clip')
-    X = df['p_raw'].astype(float).to_numpy()
-    y = df['y'].astype(float).to_numpy()
-    ir.fit(X, y)
-    cal = {'X_': ir.X_.tolist(), 'y_': ir.y_.tolist()}
+    all_preds = df['p_raw'].astype(float).to_numpy()
+    all_labels = df['y'].astype(float).to_numpy()
+    models = {}
+    if args.group_keys:
+        keys = [k.strip() for k in args.group_keys.split(',') if k.strip()]
+        for key, g in df.groupby(keys):
+            if len(g) < args.min_bin:
+                continue
+            k = key if isinstance(key, str) else '_'.join(map(str, key))
+            models[k] = fit_isotonic(g['p_raw'].astype(float).to_numpy(), g['y'].astype(float).to_numpy())
+    if not models:
+        models['_default'] = fit_isotonic(all_preds, all_labels)
     out_path = Path(args.out)
     out_path.parent.mkdir(parents=True, exist_ok=True)
     with open(out_path, 'w', encoding='utf-8') as f:
-        json.dump(cal, f, ensure_ascii=False, indent=2)
+        json.dump({'maps': models}, f, ensure_ascii=False, indent=2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- expand data contract with session metadata and conservative cost fields
- add regime-based EV gating helpers and updated order flow filters
- support grouped isotonic calibration and new reporting utilities

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7216a4ebc83308785778bbcee2a98