### PR TITLE
Handle duplicate open_time columns in prior day levels

### DIFF
--- a/backtest/strategy_v2/structure.py
+++ b/backtest/strategy_v2/structure.py
@@ -2,7 +2,10 @@ import numpy as np
 import pandas as pd
 
 def prior_day_levels(df: pd.DataFrame) -> pd.DataFrame:
-  d = df.copy()
+  # Guard against duplicate column names (e.g. multiple 'open_time' columns)
+  # which can cause ``pd.to_datetime`` to raise a ValueError when a column
+  # selection returns a DataFrame instead of a Series.
+  d = df.loc[:, ~df.columns.duplicated()].copy()
   d["date"] = pd.to_datetime(d["open_time"]).dt.floor("D")
   by = d.groupby("date")
   out = d[["open_time"]].copy()

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -4,6 +4,7 @@ import pytest
 from pathlib import Path
 
 from backtest.strategy_v2.filters import compute_bvr_ofi, ofi_conf_alignment
+from backtest.strategy_v2.structure import prior_day_levels
 
 
 @pytest.fixture
@@ -25,3 +26,12 @@ def test_ofi_features(df_eth_1m):
   assert set(['BVR','OFI']).issubset(feats.columns)
   aligned = ofi_conf_alignment(df_eth_1m)
   assert 'OFI_conf' in aligned.columns
+
+
+def test_prior_day_levels_handles_duplicates(df_eth_1m):
+  df = df_eth_1m.copy()
+  df.insert(0, 'open_time', df['open_time'], allow_duplicates=True)
+  assert df.columns.duplicated().any()
+  out = prior_day_levels(df)
+  assert set(['PDH','PDL','PDc']).issubset(out.columns)
+  assert len(out) == len(df)


### PR DESCRIPTION
## Summary
- Ensure `prior_day_levels` works when data frames contain duplicate `open_time` columns
- Add regression test for duplicate `open_time` handling

## Testing
- `PYTHONPATH=. pytest tests/test_features.py::test_prior_day_levels_handles_duplicates -q`
- `PYTHONPATH=. pytest -q` *(fails: KeyError: 'regime')*


------
https://chatgpt.com/codex/tasks/task_e_68b72fb2a3a8833085d52b2c542ce03f