### PR TITLE
fix duplicate open_time

### DIFF
--- a/backtest/runner_patched.py
+++ b/backtest/runner_patched.py
@@ -181,7 +181,8 @@ def main():
   if not paths:
     raise SystemExit('no data files')
   df = pd.concat([pd.read_csv(p) for p in paths], ignore_index=True)
-  df.rename(columns={'timestamp': 'open_time'}, inplace=True)
+  if 'timestamp' in df.columns:
+    df['open_time'] = df.pop('timestamp')
   df = ensure_ofi_columns(df)
   # open_time to UTC Timestamp conversion (vectorized)
   df = normalize_open_time(df)


### PR DESCRIPTION
## Summary
- avoid duplicate `open_time`/`timestamp` columns when loading data

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b73652872483309eefd6350c37de5a