### PR TITLE
Fix workflow indentation

### DIFF
--- a/.github/workflows/Backtest_Run_V2_LOCAL_REPOSTRAT.yml
+++ b/.github/workflows/Backtest_Run_V2_LOCAL_REPOSTRAT.yml
@@ -73,9 +73,9 @@ jobs:
           if grep -q -- "--mode" .runner_help.txt; then MODE_OPT="--mode run"; fi
           echo "MODE_OPT=$MODE_OPT" >> "$GITHUB_ENV"
 
-        - name: Run backtest
-          shell: bash
-          run: |
+      - name: Run backtest
+        shell: bash
+        run: |
             set -e
             CAL_OPT=""; if [ -f "$CALIB_JSON" ]; then CAL_OPT="--calibrator $CALIB_JSON"; fi
             install -d "out/${{ inputs.OUTDIR }}"
@@ -85,18 +85,18 @@ jobs:
               python "$RUNNER" --data-root "$DATA_ROOT" --csv-glob "$CSV_PATTERN" --params conf/params_champion.yml --outdir "out/${{ inputs.OUTDIR }}" --limit-bars 300000 --debug-level entries --no-preds $CAL_OPT
             fi
 
-        - name: Calibrator bins fallback
-          shell: bash
-          run: |
-            python tools/fit_calibrator_bins.py --preds out/${{ inputs.OUTDIR }}/preds_test.csv --out conf/calibrator_bins.json || true
+      - name: Calibrator bins fallback
+        shell: bash
+        run: |
+          python tools/fit_calibrator_bins.py --preds out/${{ inputs.OUTDIR }}/preds_test.csv --out conf/calibrator_bins.json || true
 
-        - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
-          with:
-            name: backtest_repo_${{ github.run_id }}
-            path: |
-              out/${{ inputs.OUTDIR }}/summary.json
-              out/${{ inputs.OUTDIR }}/trades.csv
-              out/${{ inputs.OUTDIR }}/gating_debug.csv
-              out/${{ inputs.OUTDIR }}/calibration_report.json
-              out/${{ inputs.OUTDIR }}/gate_waterfall.json
-            if-no-files-found: warn
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: backtest_repo_${{ github.run_id }}
+          path: |
+            out/${{ inputs.OUTDIR }}/summary.json
+            out/${{ inputs.OUTDIR }}/trades.csv
+            out/${{ inputs.OUTDIR }}/gating_debug.csv
+            out/${{ inputs.OUTDIR }}/calibration_report.json
+            out/${{ inputs.OUTDIR }}/gate_waterfall.json
+          if-no-files-found: warn


### PR DESCRIPTION
## Summary
- Align step indentation in Backtest_Run_V2_LOCAL_REPOSTRAT.yml so GitHub can parse and expose workflow dispatch

## Testing
- `python -m pip install --upgrade pip`
- `python -m pip install --prefer-binary -r requirements.txt`
- `pytest` *(fails: No CSV matched: ETHUSDT_1min_2020_2025.csv)*

------
https://chatgpt.com/codex/tasks/task_e_68b7a323f104833099c938f6bd62cc84