### PR TITLE
Add trend4u calibration utilities and runner path fix

### DIFF
--- a/backtest/runner_patched.py
+++ b/backtest/runner_patched.py
@@ -9,6 +9,7 @@ runner_patched.py — Strategy V2 (Vectorized): Conviction Gate + EV(prob-mode) 
 - Debug: gating_debug.csv (entries/exits), optional JSON
 """
 import os, sys, json, argparse, csv, math, glob, shutil
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from pathlib import Path
 import yaml
 import numpy as np

--- a/trend4u/calib/drift.py
+++ b/trend4u/calib/drift.py
@@ -2,17 +2,24 @@
 import numpy as np
 from scipy import stats
 
-def _bins(x, n=20): 
-    edges = np.quantile(x, np.linspace(0,1,n+1))
-    edges[0]-=1e-9; edges[-1]+=1e-9
+
+def _bins(x, n=20):
+    edges = np.quantile(x, np.linspace(0, 1, n + 1))
+    edges[0] -= 1e-9
+    edges[-1] += 1e-9
     return edges
 
+
 def psi(expected, actual, n=20):
-    expected=np.asarray(expected, float); actual=np.asarray(actual, float)
-    e_edges=_bins(expected, n)
-    e_hist,_=np.histogram(expected, bins=e_edges); a_hist,_=np.histogram(actual, bins=e_edges)
-    e_dist=np.clip(e_hist/e_hist.sum(),1e-8,1); a_dist=np.clip(a_hist/a_hist.sum(),1e-8,1)
-    return np.sum((a_dist-e_dist)*np.log(a_dist/e_dist))
+    expected = np.asarray(expected, float)
+    actual = np.asarray(actual, float)
+    e_edges = _bins(expected, n)
+    e_hist, _ = np.histogram(expected, bins=e_edges)
+    a_hist, _ = np.histogram(actual, bins=e_edges)
+    e = np.clip(e_hist / np.maximum(e_hist.sum(), 1), 1e-8, 1)
+    a = np.clip(a_hist / np.maximum(a_hist.sum(), 1), 1e-8, 1)
+    return float(np.sum((a - e) * np.log(a / e)))
+
 
 def ks(expected, actual):
-    return stats.ks_2samp(expected, actual).statistic
+    return float(stats.ks_2samp(expected, actual).statistic)

--- a/trend4u/calib/quantile_map.py
+++ b/trend4u/calib/quantile_map.py
@@ -1,29 +1,39 @@
 
-import numpy as np, pandas as pd, json, bisect
+import numpy as np, json, bisect
+
+
 class QuantileMap:
     def __init__(self, quantiles=None, values=None):
         self.q = quantiles or []
         self.v = values or []
+
     @staticmethod
-    def fit(scores: np.ndarray, n_bins: int = 100):
-        scores = np.asarray(scores).astype(float)
-        qs = np.linspace(0, 1, n_bins+1)
-        vals = np.quantile(scores, qs, method="linear")
-        return QuantileMap(quantiles=list(qs), values=list(vals))
-    def transform(self, scores: np.ndarray):
-        s = np.asarray(scores).astype(float)
+    def fit(scores, n_bins=100):
+        s = np.asarray(scores, float)
+        qs = np.linspace(0, 1, n_bins + 1)
+        vs = np.quantile(s, qs, method="linear")
+        return QuantileMap(list(qs), list(vs))
+
+    def transform(self, scores):
+        s = np.asarray(scores, float)
         out = np.empty_like(s)
         for i, x in enumerate(s):
             j = bisect.bisect_left(self.v, x)
-            if j<=0: out[i]=self.q[0]
-            elif j>=len(self.v): out[i]=self.q[-1]
+            if j <= 0:
+                out[i] = self.q[0]
+            elif j >= len(self.v):
+                out[i] = self.q[-1]
             else:
-                x0,x1=self.v[j-1],self.v[j]
-                q0,q1=self.q[j-1],self.q[j]
-                t=0.0 if x1==x0 else (x-x0)/(x1-x0)
-                out[i]=q0 + (q1-q0)*t
+                x0, x1 = self.v[j - 1], self.v[j]
+                q0, q1 = self.q[j - 1], self.q[j]
+                t = 0.0 if x1 == x0 else (x - x0) / (x1 - x0)
+                out[i] = q0 + (q1 - q0) * t
         return out
-    def dumps(self): return json.dumps({"q":self.q,"v":self.v})
+
+    def dumps(self):
+        return json.dumps({"q": self.q, "v": self.v})
+
     @staticmethod
-    def loads(s): 
-        o=json.loads(s); return QuantileMap(o["q"], o["v"])
+    def loads(s):
+        o = json.loads(s)
+        return QuantileMap(o["q"], o["v"])


### PR DESCRIPTION
## Summary
- Refine quantile mapping utility and drift metrics under `trend4u.calib`
- Ensure backtest runner adds repository root to `sys.path`

## Testing
- `python - <<'PY'
import sys, os
sys.path.insert(0, os.getcwd())
from trend4u.calib.quantile_map import QuantileMap
from trend4u.calib import drift
print("OK: imports working")
PY`
- `python backtest/runner_patched.py --data-root data --csv-glob ETHUSDT_1min_2020_2025.csv --params conf/params_champion.yml --outdir out`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7e18504b88330aa487d3c81636961