### PR TITLE
Fix YAML syntax error in backtest workflow

### DIFF
--- a/.github/workflows/backtest_v2_validation.yml
+++ b/.github/workflows/backtest_v2_validation.yml
@@ -96,10 +96,7 @@ jobs:
           echo "=== GATE COLUMNS PRESENT ==="
           if [ -s "$g" ]; then
             # keys from first record ∩ wanted columns (case variants for OFI)
-            jq -r '.[0] | keys
-              | map(select(. as $k | ["divergence","in_box","ofi_z","OFI_z","regime","size_frac"] | index($k)))
-              | unique
-              | .[]' "$g" || echo "[]"
+            jq -r '.[0] | keys | map(select(. as $k | ["divergence","in_box","ofi_z","OFI_z","regime","size_frac"] | index($k))) | unique | .[]' "$g" || echo "[]"
           else
             echo "[]"
           fi


### PR DESCRIPTION
## Summary
- fix GitHub Actions workflow by collapsing jq expression into a single line
- ensure gate column check step parses correctly

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b838bade18833086738eb0030960a1