### PR TITLE
feat: log gating evidence fields

### DIFF
--- a/backtest/runner_patched.py
+++ b/backtest/runner_patched.py
@@ -581,6 +581,16 @@ def main():
                 "OFI_z": float(df['ofi_z'].to_numpy()[i]), "ADX": float(adx[i]),
                 "be_armed": bool(be_armed), "decision": "enter"
             })
+            # forced evidence logging
+            _sz = (df['size_frac'].to_numpy() if 'size_frac' in df.columns else None)
+            gating_dbg[-1].update({
+                'in_box': bool(in_box[i]) if 'in_box' in locals() else None,
+                'block_lv': bool(block_lv[i]) if 'block_lv' in locals() else None,
+                'mask_blk': bool(mask_blk[i]) if 'mask_blk' in locals() else None,
+                'size_frac': (float(_sz[i]) if _sz is not None else None),
+                'denoise_applied': bool(((params.get('signal',{}) or {}).get('denoise',''))!=''),
+                'divergence': (str(df['divergence'].iloc[i]) if 'divergence' in df.columns else None)
+            })
 
         # hold until exit
         j = i + 1
@@ -613,6 +623,16 @@ def main():
                         "tp_bps_i": tp_cur, "sl_bps_i": sl_cur, "regime": str(regime[j]),
                         "OFI_z": float(df['ofi_z'].to_numpy()[j]), "ADX": float(adx[j]),
                         "be_armed": bool(be_armed), "decision": "exit"
+                    })
+                    # forced evidence logging
+                    _sz = (df['size_frac'].to_numpy() if 'size_frac' in df.columns else None)
+                    gating_dbg[-1].update({
+                        'in_box': bool(in_box[j]) if 'in_box' in locals() else None,
+                        'block_lv': bool(block_lv[j]) if 'block_lv' in locals() else None,
+                        'mask_blk': bool(mask_blk[j]) if 'mask_blk' in locals() else None,
+                        'size_frac': (float(_sz[j]) if _sz is not None else None),
+                        'denoise_applied': bool(((params.get('signal',{}) or {}).get('denoise',''))!=''),
+                        'divergence': (str(df['divergence'].iloc[j]) if 'divergence' in df.columns else None)
                     })
                 position = 0; entry_idx = -1; entry_px = 0.0
                 break


### PR DESCRIPTION
## Summary
- force evidence fields into gating debug records, capturing box/blocks, size, denoise status, and divergence

## Testing
- `python backtest/runner_patched.py --data-root data --csv-glob "ETHUSDT*.csv" --params conf/params_champion.yml --flags conf/feature_flags.yml --outdir _out_v2/smoke --debug-level entries --limit-bars 150000`
- `python - <<'PY'
import os, json, pandas as pd, sys

base = "_out_v2/smoke"
ok = True; missing = []

# 1) summary.json
s = {}
p = os.path.join(base,"summary.json")
if os.path.exists(p) and os.path.getsize(p)>0:
    s = json.load(open(p))
else:
    ok=False; missing += ["summary.json"]

ntr = s.get('num_trades') or s.get('n_trades') or 0
if ntr <= 0: ok=False; missing += ["num_trades>0"]

# 2) gating_debug.json
g = os.path.join(base,"gating_debug.json")
if not (os.path.exists(g) and os.path.getsize(g)>0):
    ok=False; missing += ["gating_debug.json"]
    dbg = pd.DataFrame()
else:
    dbg = pd.read_json(g)

need_cols = [
  'in_box','block_lv','mask_blk','size_frac',
  'denoise_applied','regime','OFI_z','p_ev_req','ev_bps','tp_bps_i','sl_bps_i','ADX','decision'
]
for c in need_cols:
    if c not in dbg.columns: ok=False; missing += [f"col:{c}"]

# 3) trades.csv (참고치)
t = os.path.join(base,"trades.csv")
trades = pd.read_csv(t) if (os.path.exists(t) and os.path.getsize(t)>0) else pd.DataFrame()

# 출력
print("=== PASS ===" if ok else "=== FAIL ===")
print({"num_trades": int(ntr), "winrate": s.get("winrate"), "mcc": s.get("mcc"), "cum_pnl_bps": s.get("cum_pnl_bps")})
print({"missing": missing})

# 간단 기여도 스냅샷
snap = {
  "decision_counts": (dbg["decision"].value_counts().to_dict() if "decision" in dbg else {}),
  "regime_counts": (dbg["regime"].value_counts().to_dict() if "regime" in dbg else {}),
  "ofi_z_mean": float(dbg["OFI_z"].mean()) if "OFI_z" in dbg else None,
  "p_ev_req_mean": float(dbg["p_ev_req"].mean()) if "p_ev_req" in dbg else None,
  "ev_bps_mean": float(dbg["ev_bps"].mean()) if "ev_bps" in dbg else None,
  "tp/sl_mean": (
      float(dbg["tp_bps_i"].mean()) if "tp_bps_i" in dbg else None,
      float(dbg["sl_bps_i"].mean()) if "sl_bps_i" in dbg else None
  ),
  "size_frac_minmax": (
      float(dbg["size_frac"].min()) if "size_frac" in dbg else None,
      float(dbg["size_frac"].max()) if "size_frac" in dbg else None
  )
}
print({"snapshot": snap})

# CSV 리포트
out = os.path.join(base, "v2_validation_report.csv")
pd.DataFrame([{
  **{"num_trades": ntr, "winrate": s.get("winrate"), "mcc": s.get("mcc"), "cum_pnl_bps": s.get("cum_pnl_bps")},
  **{f"has_{c}": (c in dbg.columns) for c in need_cols}
}]).to_csv(out, index=False)
print("[saved]", out)
sys.exit(0 if ok else 2)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b8498361a8833080100ab2f3e31d25