### PR TITLE
fix: allow specifying run id for artifact download

### DIFF
--- a/.github/workflows/backtest_v2_train.yml
+++ b/.github/workflows/backtest_v2_train.yml
@@ -2,6 +2,11 @@ name: Backtest V2 Train Model
 
 on:
   workflow_dispatch:
+    inputs:
+      DIAG_RUN_ID:
+        description: 'workflow run id of BacktestV2-Diagnostics-Alignment'
+        required: true
+        type: string
 
 jobs:
   train:
@@ -33,6 +38,8 @@ jobs:
         with:
           name: backtest_v2_diag_align
           path: _out_4u/run
+          run-id: ${{ inputs.DIAG_RUN_ID }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Train model
         run: |


### PR DESCRIPTION
## Summary
- allow providing DIAG_RUN_ID input so training workflow can fetch artifacts from previous run
- pass run ID and token to download-artifact step

## Testing
- `pytest` *(fails: SyntaxError and 13 failed, 11 passed, 2 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b92c9abb7083308e140b8d18fd92e2