### PR TITLE
fix download-artifact reference in backtest train workflow

### DIFF
--- a/.github/workflows/backtest_v2_train.yml
+++ b/.github/workflows/backtest_v2_train.yml
@@ -18,8 +18,8 @@ jobs:
           set -e
           git ls-remote https://github.com/actions/checkout | grep 08c6903cd8c0fde910a37f88322edcfb5dd907a8
           git ls-remote https://github.com/actions/setup-python | grep a26af69be951a213d495a4c3e4e4022e16d87065
-          git ls-remote https://github.com/actions/upload-artifact | grep ea165f8d65b6e75b540449e92b4886f43607fa02
-          git ls-remote https://github.com/actions/download-artifact | grep 694cdabd8bdb022872a0656a84eb2e172f79dbb0
+          git ls-remote https://github.com/actions/upload-artifact   | grep ea165f8d65b6e75b540449e92b4886f43607fa02
+          git ls-remote https://github.com/actions/download-artifact | grep refs/tags/v4
 
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
@@ -35,7 +35,7 @@ jobs:
           pip install pandas numpy scikit-learn joblib
 
       - name: Download backtest outputs
-        uses: actions/download-artifact@694cdabd8bdb022872a0656a84eb2e172f79dbb0
+        uses: actions/download-artifact@v4
         with:
           name: backtest_v2_diag_align
           path: _out_4u


### PR DESCRIPTION
## Summary
- use actions/download-artifact@v4 instead of invalid commit
- validate existence of v4 tag during workflow setup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b9a7b0d13483309c934a2149184ed7