### PR TITLE
fix: update download-artifact version

### DIFF
--- a/.github/workflows/backtest_v2_rerun.yml
+++ b/.github/workflows/backtest_v2_rerun.yml
@@ -18,7 +18,7 @@ jobs:
           git ls-remote https://github.com/actions/checkout | grep 08c6903cd8c0fde910a37f88322edcfb5dd907a8
           git ls-remote https://github.com/actions/setup-python | grep a26af69be951a213d495a4c3e4e4022e16d87065
           git ls-remote https://github.com/actions/upload-artifact | grep ea165f8d65b6e75b540449e92b4886f43607fa02
-          git ls-remote https://github.com/actions/download-artifact | grep 694cdabd8bdb022872a0656a84eb2e172f79dbb0
+          git ls-remote https://github.com/actions/download-artifact | grep refs/tags/v4
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
       - name: Set up Python
@@ -30,12 +30,12 @@ jobs:
           python -m pip install --upgrade pip
           pip install pandas numpy scikit-learn
       - name: Download artifacts
-        uses: actions/download-artifact@694cdabd8bdb022872a0656a84eb2e172f79dbb0
+        uses: actions/download-artifact@v4
         with:
           name: backtest_v2_diag_align
           path: _out_4u
       - name: Download model
-        uses: actions/download-artifact@694cdabd8bdb022872a0656a84eb2e172f79dbb0
+        uses: actions/download-artifact@v4
         with:
           name: trained-model
           path: conf


### PR DESCRIPTION
## Summary
- update GitHub workflow to use actions/download-artifact@v4
- validate tag instead of removed commit for download-artifact

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9aeba0cd483309d98abd9a6538636