### PR TITLE
Fix YAML indentation in diagnostics workflow

### DIFF
--- a/.github/workflows/backtest_v2_diag_align.yml
+++ b/.github/workflows/backtest_v2_diag_align.yml
@@ -82,15 +82,15 @@ jobs:
           fi
           # print reason counts for visibility
           python - <<'PY'
-import json, os
-base = "_out_4u/run/summary.json"
-if os.path.exists(base):
-    try:
-        data = json.load(open(base))
-        print("Reason counts:", data.get("reason_counts"))
-    except Exception as e:
-        print("Reason counts: <error>", e)
-PY
+            import json, os
+            base = "_out_4u/run/summary.json"
+            if os.path.exists(base):
+                try:
+                    data = json.load(open(base))
+                    print("Reason counts:", data.get("reason_counts"))
+                except Exception as e:
+                    print("Reason counts: <error>", e)
+          PY
 
       - name: (1) Diagnostics — numbers only
         shell: bash


### PR DESCRIPTION
## Summary
- fix indentation in `backtest_v2_diag_align.yml` so GitHub parses the workflow correctly

## Testing
- `python - <<'PY'
import yaml, sys
for f in ['.github/workflows/backtest_v2_rerun.yml','.github/workflows/backtest_v2_train.yml','.github/workflows/backtest_v2_diag_align.yml']:
    with open(f) as fh:
        yaml.safe_load(fh)
    print('Parsed', f)
PY`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9be8e44008330b5acff048788c13b