### PR TITLE
Fix artifact paths and align model features for prediction

### DIFF
--- a/.github/workflows/backtest_v2_rerun.yml
+++ b/.github/workflows/backtest_v2_rerun.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: backtest_v2_diag_align
-          path: _out_4u
+          path: .
       - name: Download model
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/backtest_v2_train.yml
+++ b/.github/workflows/backtest_v2_train.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: backtest_v2_diag_align
-          path: _out_4u
+          path: .
 
       - name: List artifact files
         run: ls -R _out_4u

--- a/runner_patched.py
+++ b/runner_patched.py
@@ -194,7 +194,7 @@ def main():
         model_path = repo_root/'conf'/'model.pkl'
         if not model_path.exists():
             raise FileNotFoundError("conf/model.pkl not found; run training workflow first")
-        X = pd.DataFrame({
+        X_full = pd.DataFrame({
             'p_trend': p_base,
             'macd_hist': macd_diff,
             'rsi': df['rsi'],
@@ -202,6 +202,8 @@ def main():
             'ofi': df['ofi']
         }).fillna(0.0)
         clf = joblib.load(model_path)
+        feature_cols = getattr(clf, 'feature_names_in_', X_full.columns)
+        X = X_full[list(feature_cols)]
         p_raw = clf.predict_proba(X)[:,1]
         p_trend = p_raw
         if calibrator is not None:


### PR DESCRIPTION
## Summary
- Correct artifact download paths in training and rerun workflows
- Restrict features passed to trained model in runner to match training features

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba5a8a76448330b6483de161ba9f06